### PR TITLE
Kaveesha/add sync hashing

### DIFF
--- a/server/rag/pipeline/ingestion/chunking/process_corpus.py
+++ b/server/rag/pipeline/ingestion/chunking/process_corpus.py
@@ -1,6 +1,7 @@
 import uuid
 import re
 from pathlib import Path
+import hashlib
 
 from parser import extract_frontmatter
 from section_extracter import extract_sections
@@ -324,6 +325,9 @@ def process_markdown_file(file_path):
     with open(file_path, "r", encoding="utf-8") as f:
         content = f.read()
 
+    # Calculate MD5 hash of the file content
+    file_hash = hashlib.md5(content.encode("utf-8")).hexdigest()
+
     metadata, body = extract_frontmatter(content)
 
     sections = extract_sections(body)
@@ -426,6 +430,7 @@ def process_markdown_file(file_path):
 
                 "path": str(file_path),
                 "source_file": file_path.name,
+                "file_hash": file_hash,
 
                 "scraped_date": metadata.get("scraped_date"),
 
@@ -478,6 +483,7 @@ def process_markdown_file(file_path):
 
             "path": str(file_path),
             "source_file": file_path.name,
+            "file_hash": file_hash, 
 
             "scraped_date": metadata.get("scraped_date"),
 

--- a/server/rag/pipeline/ingestion/sync_incremental.py
+++ b/server/rag/pipeline/ingestion/sync_incremental.py
@@ -37,12 +37,25 @@ def main():
     with open(METADATA_FILE, "r", encoding="utf-8") as f:
         metadata = json.load(f)
 
-    existing_files = {chunk.get("source_file") for chunk in metadata if chunk.get("source_file")}
+    # Helper to convert paths to a canonical format relative to DATA_DIR
+    def get_canonical_path(path_str):
+        try:
+            return Path(path_str).resolve().relative_to(DATA_DIR.resolve()).as_posix().lower()
+        except ValueError:
+            return Path(path_str).as_posix().lower()
+
+    existing_files = {
+        get_canonical_path(chunk.get("path"))
+        for chunk in metadata if chunk.get("path")
+    }
     logger.info("Found %d chunks representing %d unique files in current index.", len(metadata), len(existing_files))
 
     logger.info("Scanning directory: %s", DATA_DIR)
     md_files = list(DATA_DIR.rglob("*.md"))
-    new_files = [f for f in md_files if f.name not in existing_files]
+    new_files = [
+        f for f in md_files 
+        if get_canonical_path(f) not in existing_files
+    ]
 
     if not new_files:
         logger.info("No new markdown files found. Database is up to date!")

--- a/server/rag/pipeline/ingestion/sync_incremental.py
+++ b/server/rag/pipeline/ingestion/sync_incremental.py
@@ -8,6 +8,7 @@ from dotenv import load_dotenv
 from pinecone import Pinecone
 from sentence_transformers import SentenceTransformer
 import torch
+import hashlib
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s — %(message)s")
 logger = logging.getLogger(__name__)
@@ -37,37 +38,99 @@ def main():
     with open(METADATA_FILE, "r", encoding="utf-8") as f:
         metadata = json.load(f)
 
+    CHUNKING_DIR = INGESTION_DIR / "chunking"
+
     # Helper to convert paths to a canonical format relative to DATA_DIR
     def get_canonical_path(path_str):
         try:
-            return Path(path_str).resolve().relative_to(DATA_DIR.resolve()).as_posix().lower()
+            p = Path(path_str)
+            if not p.is_absolute():
+                # Relative paths in metadata are relative to the chunking directory
+                p = (CHUNKING_DIR / p).resolve()
+            else:
+                p = p.resolve()
+            return p.relative_to(DATA_DIR.resolve()).as_posix().lower()
         except ValueError:
             return Path(path_str).as_posix().lower()
 
-    existing_files = {
-        get_canonical_path(chunk.get("path"))
-        for chunk in metadata if chunk.get("path")
-    }
-    logger.info("Found %d chunks representing %d unique files in current index.", len(metadata), len(existing_files))
-
     logger.info("Scanning directory: %s", DATA_DIR)
     md_files = list(DATA_DIR.rglob("*.md"))
-    new_files = [
-        f for f in md_files 
-        if get_canonical_path(f) not in existing_files
-    ]
 
-    if not new_files:
-        logger.info("No new markdown files found. Database is up to date!")
+    # 1. First, pre-calculate hashes of all files on disk
+    current_file_hashes = {}
+    for f in md_files:
+        canonical_path = get_canonical_path(f)
+        try:
+            with open(f, "r", encoding="utf-8") as file_obj:
+                content = file_obj.read()
+            current_file_hashes[canonical_path] = hashlib.md5(content.encode("utf-8")).hexdigest()
+        except Exception as e:
+            logger.error("Failed to read/hash file %s: %s", f, e)
+
+    # 2. Upgrade existing metadata on-the-fly (Backfill missing file_hash keys)
+    metadata_updated = False
+    for chunk in metadata:
+        path = chunk.get("path")
+        if path and not chunk.get("file_hash"):
+            canonical_path = get_canonical_path(path)
+            disk_hash = current_file_hashes.get(canonical_path)
+            if disk_hash:
+                chunk["file_hash"] = disk_hash
+                metadata_updated = True
+
+    if metadata_updated:
+        logger.info("Backfilling missing file_hash keys in existing metadata.json...")
+        with open(METADATA_FILE, "w", encoding="utf-8") as f_out:
+            json.dump(metadata, f_out, ensure_ascii=False)
+        logger.info("Local metadata.json migration complete.")
+
+    # 3. Map existing files to their last known hashes
+    existing_file_hashes = {}
+    for chunk in metadata:
+        path = chunk.get("path")
+        if path and chunk.get("file_hash"):
+            canonical_path = get_canonical_path(path)
+            existing_file_hashes[canonical_path] = chunk["file_hash"]
+
+    logger.info("Found %d chunks representing %d unique files in current index.", len(metadata), len(existing_file_hashes))
+
+    new_files = []
+    updated_files = []
+
+    # 4. Check each file for changes
+    for f in md_files:
+        canonical_path = get_canonical_path(f)
+        current_hash = current_file_hashes.get(canonical_path)
+        if not current_hash:
+            continue
+
+        if canonical_path not in existing_file_hashes:
+            # Completely new file
+            new_files.append(f)
+        elif existing_file_hashes[canonical_path] != current_hash:
+            # Existing file that was modified
+            updated_files.append((f, canonical_path))
+
+    # Combine both lists as files that need processing
+    files_to_process = new_files + [f for f, _ in updated_files]
+
+    if not files_to_process:
+        logger.info("No new or modified markdown files found. Database is up to date!")
         sys.exit(0)
 
-    logger.info("Found %d new files to process:", len(new_files))
-    for f in new_files:
-        logger.info("  - %s", f.relative_to(DATA_DIR))
+    if new_files:
+        logger.info("Found %d new files to process:", len(new_files))
+        for f in new_files:
+            logger.info("  - [NEW] %s", f.relative_to(DATA_DIR))
+            
+    if updated_files:
+        logger.info("Found %d modified files to update:", len(updated_files))
+        for f, _ in updated_files:
+            logger.info("  - [MODIFIED] %s", f.relative_to(DATA_DIR))
 
-    # 1. Chunk only new files
+    # 1. Chunk only modified/new files
     new_chunks = []
-    for md_file in new_files:
+    for md_file in files_to_process:
         try:
             chunks = process_markdown_file(md_file)
             new_chunks.extend(chunks)
@@ -75,6 +138,7 @@ def main():
         except Exception as e:
             logger.error("Failed to chunk %s: %s", md_file, e)
 
+    
     if not new_chunks:
         logger.warning("No new chunks generated. Exiting.")
         sys.exit(0)
@@ -94,7 +158,25 @@ def main():
         convert_to_numpy=True
     ).astype("float32")
 
-    # 3. Concatenate and save local vector store files
+    # 3. Clean local metadata & embeddings for updated files first
+    if updated_files:
+        logger.info("Removing old chunks for %d updated files from local index...", len(updated_files))
+        files_to_remove = {canonical_path for _, canonical_path in updated_files}
+        
+        keep_indices = []
+        for idx, chunk in enumerate(metadata):
+            path = chunk.get("path")
+            if path and get_canonical_path(path) in files_to_remove:
+                continue
+            keep_indices.append(idx)
+            
+        metadata = [metadata[idx] for idx in keep_indices]
+        
+        old_embeddings = np.load(EMBEDDINGS_FILE)
+        old_embeddings = old_embeddings[keep_indices]
+        np.save(EMBEDDINGS_FILE, old_embeddings)
+
+    # Save updated local embeddings and metadata
     logger.info("Saving updated local embeddings and metadata...")
     old_embeddings = np.load(EMBEDDINGS_FILE)
     updated_embeddings = np.concatenate((old_embeddings, new_embeddings), axis=0)
@@ -115,6 +197,19 @@ def main():
     logger.info("Connecting to Pinecone...")
     pc = Pinecone(api_key=api_key)
     index = pc.Index(index_name)
+
+    # Delete old vectors for modified files from Pinecone
+    if updated_files:
+        logger.info("Deleting old vectors from Pinecone for %d modified files...", len(updated_files))
+        for f, canonical_path in updated_files:
+            # Generate the document_id using the exact same formula
+            import uuid
+            doc_id = str(uuid.uuid5(uuid.NAMESPACE_DNS, f.as_posix()))
+            try:
+                index.delete(filter={"document_id": doc_id})
+                logger.info("  Deleted old vectors for: %s", canonical_path)
+            except Exception as e:
+                logger.error("Failed to delete vectors for %s from Pinecone: %s", canonical_path, e)
 
     logger.info("Preparing vectors for Pinecone upload...")
     vectors = []


### PR DESCRIPTION
### What this does
Upgrades the incremental sync script to support file content changes (MD5 hashing). Now, if we edit or update an existing file on disk, the database will detect the change, remove the old vectors, and upload the updated ones.

### How it works
* Calculates the MD5 hash of a file when chunking and stores it in the metadata.
* Compares the stored hash to the file on disk during `sync_incremental.py`.
* If a file is modified, it clears its old chunks from `metadata.json`/`embeddings.npy`, deletes the old vectors from Pinecone (using `document_id`), and embeds the new ones.
* Includes an auto-migration that backfills missing hashes in `metadata.json` in under a second so we don't have to rebuild the database from scratch.

### Testing
Verified by creating a test file, modifying its contents, and running the sync script:
* First run: Detected file as `[NEW]` and uploaded.
* Second run (after editing): Detected file as `[MODIFIED]`, successfully deleted old Pinecone vectors, and uploaded only the updated chunk.