### PR TITLE
feat(frontend): Faculty Dashboard live data, Calendar UI & UniRP markers [Manal — AURA v6]

### DIFF
--- a/aura/components/features/chat-v2/FacultyDashboard.tsx
+++ b/aura/components/features/chat-v2/FacultyDashboard.tsx
@@ -1,7 +1,8 @@
 "use client"
 
-import React from "react"
-import { Calendar, Users, Clock, AlertCircle, ArrowRight } from "lucide-react"
+import React, { useEffect, useState } from "react"
+import { Calendar, Users, ArrowRight, Loader2, AlertCircle, Clock } from "lucide-react"
+import { apiFetch } from "@/lib/auth-client"
 
 interface FacultyDashboardProps {
   userName: string
@@ -9,21 +10,109 @@ interface FacultyDashboardProps {
   onSelectPrompt: (text: string) => void
 }
 
-export function FacultyDashboard({ userName, departmentName = "Information & Communication Technology", onSelectPrompt }: FacultyDashboardProps) {
-  const schedule = [
-    { time: "10:00 AM - 11:30 AM", course: "Computer Networks (IT-302) - PG", room: "Room 201" },
-    { time: "02:00 PM - 05:00 PM", course: "Database Management Lab (IT-204) - UG", room: "Lab 1" },
-  ]
+type CardState = "loading" | "done" | "error"
 
-  const alerts = [
-    { title: "Networks Lab Grade Sheet", due: "10th July (In 6 days)" },
-  ]
+/**
+ * Fetches a single AURA chat answer for use in dashboard cards.
+ * Returns the accumulated text-delta from the SSE stream.
+ *
+ * TODO(unirp): When faculty data routes migrate to UniRP API, update this
+ * helper to call UniRP endpoints directly. Do NOT implement UniRP logic
+ * until routes are confirmed. Current path: AURA RAG + ERP connector.
+ */
+async function fetchDashboardAnswer(question: string): Promise<string> {
+  const res = await apiFetch("/api/chat", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ question, history: [] }),
+  })
+
+  if (!res.ok || !res.body) return ""
+
+  const reader = res.body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ""
+  let answer = ""
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    buffer += decoder.decode(value, { stream: true })
+    const lines = buffer.split("\n")
+    buffer = lines.pop() ?? ""
+    for (const line of lines) {
+      const trimmed = line.trim()
+      if (trimmed.startsWith("data:")) {
+        const data = trimmed.slice(5).trim()
+        if (data === "[DONE]") break
+        try {
+          const chunk = JSON.parse(data) as { type?: string; delta?: string }
+          if (chunk.type === "text-delta" && typeof chunk.delta === "string") {
+            answer += chunk.delta
+          }
+        } catch {
+          /* skip malformed chunk */
+        }
+      }
+    }
+  }
+
+  return answer
+}
+
+function CardSkeleton({ rows = 2 }: { rows?: number }) {
+  return (
+    <div className="animate-pulse space-y-2.5">
+      {Array.from({ length: rows }).map((_, i) => (
+        <div
+          key={i}
+          className="h-10 rounded-xl bg-theme-gray-light/40"
+          style={{ opacity: 1 - i * 0.25 }}
+        />
+      ))}
+    </div>
+  )
+}
+
+export function FacultyDashboard({
+  userName,
+  departmentName = "Information & Communication Technology",
+  onSelectPrompt,
+}: FacultyDashboardProps) {
+  const [scheduleText, setScheduleText] = useState("")
+  const [scheduleState, setScheduleState] = useState<CardState>("loading")
+  const [adviseeText, setAdviseeText] = useState("")
+  const [adviseeState, setAdviseeState] = useState<CardState>("loading")
+
+  useEffect(() => {
+    // Fetch faculty today's schedule and advisee count in parallel on mount.
+    // TODO(unirp): Replace with UniRP endpoint when faculty data routes are confirmed.
+    // Do NOT implement any UniRP logic until routes are provided.
+    void Promise.all([
+      fetchDashboardAnswer("What is my teaching schedule for today?")
+        .then((text) => {
+          setScheduleText(text)
+          setScheduleState(text.trim() ? "done" : "error")
+        })
+        .catch(() => setScheduleState("error")),
+      fetchDashboardAnswer("How many advisees do I currently have?")
+        .then((text) => {
+          setAdviseeText(text)
+          setAdviseeState(text.trim() ? "done" : "error")
+        })
+        .catch(() => setAdviseeState("error")),
+    ])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // Attendance card is intentionally absent:
+  // eCampus attendance data is unavailable. Revisit when UniRP exposes this endpoint.
 
   const quickPrompts = [
     "What is my class schedule today?",
-    "Show pending grade submissions",
     "List my BTP mentee groups",
     "Check room availability for seminar",
+    "What are my responsibilities on the exam committee?",
   ]
 
   return (
@@ -39,57 +128,107 @@ export function FacultyDashboard({ userName, departmentName = "Information & Com
       </div>
 
       <div className="grid grid-cols-1 gap-5 md:grid-cols-2">
-        {/* Teaching schedule */}
+        {/* Today's Teaching Schedule — wired to faculty_schedule via AURA chat pipeline */}
         <div className="rounded-2xl border border-theme-gray-light bg-theme-gray/80 p-5">
           <h2 className="mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-neutral-400">
             <Calendar className="size-3.5 text-theme-yellow" />
             Today&apos;s Schedule
+            {scheduleState === "loading" && (
+              <Loader2 className="ml-auto size-3 animate-spin text-neutral-600" />
+            )}
           </h2>
-          <div className="space-y-3">
-            {schedule.map((item, idx) => (
-              <div key={idx} className="flex flex-col gap-1 rounded-xl bg-theme-gray-light/40 p-3 border border-transparent hover:border-theme-gray-light transition-colors">
-                <span className="flex items-center gap-1 text-[10px] text-neutral-400">
-                  <Clock className="size-3" />
-                  {item.time}
-                </span>
-                <span className="text-sm font-medium text-neutral-200">{item.course}</span>
-                <span className="text-xs text-neutral-500">{item.room}</span>
-              </div>
-            ))}
-          </div>
+
+          {scheduleState === "loading" ? (
+            <CardSkeleton rows={2} />
+          ) : scheduleState === "error" || !scheduleText.trim() ? (
+            <div className="flex flex-col gap-1.5 rounded-xl border border-theme-gray-light/30 bg-theme-gray-light/10 p-3">
+              <span className="flex items-center gap-1.5 text-xs text-neutral-500">
+                <AlertCircle className="size-3.5 shrink-0" />
+                Schedule unavailable
+              </span>
+              <span className="text-[10px] leading-relaxed text-neutral-600">
+                {/*
+                  Faculty schedule is derived from aggregated student timetable data.
+                  Coverage grows as more students link their eCampus accounts.
+                  TODO(unirp): Will be replaced by UniRP endpoint when routes are confirmed.
+                */}
+                AURA derives your schedule from student timetable data. Coverage
+                improves as more students link eCampus.
+              </span>
+            </div>
+          ) : (
+            <div className="rounded-xl border border-theme-gray-light/20 bg-theme-gray-light/20 p-3">
+              <p className="line-clamp-8 whitespace-pre-line text-xs leading-relaxed text-neutral-300">
+                {scheduleText}
+              </p>
+            </div>
+          )}
         </div>
 
-        {/* Alerts & Mentees */}
+        {/* Right column */}
         <div className="flex flex-col gap-5">
+          {/* Advisee Count — wired to composite_tools.get_advisee_snapshot via AURA chat */}
           <div className="flex-1 rounded-2xl border border-theme-gray-light bg-theme-gray/80 p-5">
             <h2 className="mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-neutral-400">
-              <AlertCircle className="size-3.5 text-theme-yellow" />
-              Pending Tasks
+              <Users className="size-3.5 text-theme-yellow" />
+              Advisees
+              {adviseeState === "loading" && (
+                <Loader2 className="ml-auto size-3 animate-spin text-neutral-600" />
+              )}
             </h2>
-            <div className="space-y-2.5">
-              {alerts.map((item, idx) => (
-                <div key={idx} className="flex flex-col gap-1 rounded-xl bg-theme-red/5 border border-theme-red/20 p-3">
-                  <span className="text-xs font-medium text-neutral-200">{item.title}</span>
-                  <span className="text-[10px] text-theme-red font-medium">Due: {item.due}</span>
-                </div>
-              ))}
-            </div>
+
+            {adviseeState === "loading" ? (
+              <CardSkeleton rows={1} />
+            ) : adviseeState === "error" || !adviseeText.trim() ? (
+              <div className="flex items-center gap-2 rounded-xl border border-theme-gray-light/30 bg-theme-gray-light/10 px-3 py-2.5">
+                <AlertCircle className="size-3.5 shrink-0 text-neutral-600" />
+                <span className="text-xs text-neutral-500">
+                  Advisee data unavailable
+                </span>
+              </div>
+            ) : (
+              <div className="rounded-xl border border-theme-gray-light/20 bg-theme-gray-light/20 p-3">
+                <p className="line-clamp-4 text-xs leading-relaxed text-neutral-300">
+                  {adviseeText}
+                </p>
+              </div>
+            )}
+
+            <button
+              type="button"
+              onClick={() => onSelectPrompt("List all my advisees and their current semester details")}
+              className="mt-2.5 flex items-center gap-1 text-[10px] font-medium text-theme-yellow transition-colors hover:text-theme-yellow/70"
+            >
+              <ArrowRight className="size-3" />
+              View all advisees in chat
+            </button>
           </div>
 
+          {/* Calendar — prompt shortcut; full booking UI activates when Backend M3 ships */}
           <div className="rounded-2xl border border-theme-gray-light bg-theme-gray/80 p-5">
             <h2 className="mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-neutral-400">
-              <Users className="size-3.5 text-theme-yellow" />
-              Project Mentees (BTP)
+              <Clock className="size-3.5 text-theme-yellow" />
+              Calendar
             </h2>
-            <div className="flex items-center justify-between rounded-xl bg-theme-gray-light/40 px-4 py-2">
-              <span className="text-xs text-neutral-300">Supervised Groups</span>
-              <span className="text-xs font-semibold text-theme-yellow bg-theme-yellow/10 border border-theme-yellow/20 px-2 py-0.5 rounded-full">4 Teams (12 studs)</span>
+            <div className="flex items-center justify-between rounded-xl bg-theme-gray-light/40 px-4 py-2.5">
+              <span className="text-xs text-neutral-400">
+                Book a meeting or set a reminder
+              </span>
+              <button
+                type="button"
+                onClick={() =>
+                  onSelectPrompt("Set a reminder for my next department meeting")
+                }
+                className="text-[10px] font-medium text-theme-yellow transition-colors hover:text-theme-yellow/70"
+              >
+                Ask AURA →
+              </button>
             </div>
           </div>
         </div>
       </div>
 
-      {/* Suggested queries */}
+      {/* Quick Prompts */}
       <div className="mt-8">
         <h3 className="mb-3 text-[10px] font-semibold uppercase tracking-wider text-neutral-500">
           Quick Actions
@@ -100,10 +239,10 @@ export function FacultyDashboard({ userName, departmentName = "Information & Com
               key={prompt}
               type="button"
               onClick={() => onSelectPrompt(prompt)}
-              className="flex items-center justify-between rounded-xl border border-theme-gray-light bg-theme-gray/60 px-4 py-2.5 text-left text-xs text-neutral-300 hover:border-theme-gray-lighter hover:bg-theme-gray-light hover:text-neutral-100 transition-all group"
+              className="flex items-center justify-between rounded-xl border border-theme-gray-light bg-theme-gray/60 px-4 py-2.5 text-left text-xs text-neutral-300 transition-all hover:border-theme-gray-lighter hover:bg-theme-gray-light hover:text-neutral-100 group"
             >
               <span>{prompt}</span>
-              <ArrowRight className="size-3.5 opacity-0 group-hover:opacity-100 transition-opacity text-theme-yellow" />
+              <ArrowRight className="size-3.5 opacity-0 transition-opacity group-hover:opacity-100 text-theme-yellow" />
             </button>
           ))}
         </div>

--- a/aura/components/features/chat-v2/Message.tsx
+++ b/aura/components/features/chat-v2/Message.tsx
@@ -1,10 +1,10 @@
 "use client"
 
 import { useState } from "react"
-import { Check, Copy, RotateCcw, ThumbsDown, ThumbsUp, FileText, Lock } from "lucide-react"
+import { Check, Copy, RotateCcw, ThumbsDown, ThumbsUp, FileText, Lock, CalendarCheck } from "lucide-react"
 import { toast } from "sonner"
 import { cn } from "@/lib/utils"
-import type { ChatMessage, Citation } from "@/lib/chat-types"
+import type { ChatMessage, Citation, CalendarActionData } from "@/lib/chat-types"
 import { BrandMark } from "@/components/common/BrandMark"
 import { MarkdownContent } from "@/components/common/MarkdownContent"
 
@@ -100,6 +100,11 @@ export function Message({ message, citations, onRegenerate }: MessageProps) {
         )}
         <MarkdownContent content={message.content} />
 
+        {/* Calendar booking confirmation — renders when backend emits a calendar-action event */}
+        {message.calendar_action && (
+          <BookingConfirmationCard action={message.calendar_action} />
+        )}
+
         {citations && citations.length > 0 ? (
           <div className="mt-3 flex flex-wrap gap-3">
             {citations.map((c, i) => {
@@ -181,5 +186,76 @@ function ActionButton({ label, onClick, active, children }: ActionButtonProps) {
     >
       {children}
     </button>
+  )
+}
+
+/**
+ * Booking confirmation card — shown inline within an assistant message when
+ * the backend calendar tool creates or confirms a Google Calendar event.
+ * Backend M3 (Dhruvam) owns the tool logic; this is the frontend display half.
+ */
+function BookingConfirmationCard({ action }: { action: CalendarActionData }) {
+  const isConfirmed = action.status === "confirmed"
+  const isFailed = action.status === "failed"
+
+  return (
+    <div
+      className={cn(
+        "mt-3 rounded-xl border p-4",
+        isFailed
+          ? "border-theme-red/20 bg-theme-red/5"
+          : "border-theme-yellow/20 bg-theme-yellow/5",
+      )}
+    >
+      <div className="flex items-start gap-2.5">
+        <CalendarCheck
+          className={cn(
+            "mt-0.5 size-4 shrink-0",
+            isFailed ? "text-theme-red" : "text-theme-yellow",
+          )}
+        />
+        <div className="min-w-0 flex-1">
+          <p
+            className={cn(
+              "mb-1 text-xs font-semibold",
+              isFailed ? "text-theme-red" : "text-theme-yellow",
+            )}
+          >
+            {isFailed
+              ? "Calendar event could not be created"
+              : isConfirmed
+              ? "Calendar event confirmed"
+              : "Calendar event pending"}
+          </p>
+          {action.event_title && (
+            <p className="text-sm font-medium text-neutral-200">{action.event_title}</p>
+          )}
+          {action.description && (
+            <p className="mt-0.5 text-xs text-neutral-400">{action.description}</p>
+          )}
+          {(action.date || action.time) && (
+            <p className="mt-1 flex items-center gap-1.5 text-xs text-neutral-400">
+              <CalendarCheck className="size-3 shrink-0" />
+              {[action.date, action.time].filter(Boolean).join(" · ")}
+            </p>
+          )}
+          {action.attendees && action.attendees.length > 0 && (
+            <p className="mt-1 text-xs text-neutral-500">
+              With: {action.attendees.join(", ")}
+            </p>
+          )}
+          {action.calendar_link && (
+            <a
+              href={action.calendar_link}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-2 inline-flex items-center gap-1 text-xs text-theme-yellow transition-colors hover:underline"
+            >
+              View in Google Calendar →
+            </a>
+          )}
+        </div>
+      </div>
+    </div>
   )
 }

--- a/aura/hooks/use-aura-chat.ts
+++ b/aura/hooks/use-aura-chat.ts
@@ -6,6 +6,7 @@ import type {
   ChatThread,
   Citation,
   StudentProfile,
+  CalendarActionData,
 } from "@/lib/chat-types"
 import { useSession } from "next-auth/react"
 import { apiFetch, setToken, initAuth } from "@/lib/auth-client"
@@ -292,6 +293,7 @@ export function useAuraChat() {
         let assistantText = ""
         let citations: Citation[] = []
         let isPersonalData = false
+        let calendarAction: CalendarActionData | undefined
         const assistantMsg: ChatMessage = {
           role: "assistant",
           content: "",
@@ -313,12 +315,25 @@ export function useAuraChat() {
             setActiveCitations(citations)
           } else if (chunk.type === "personal-data-flag") {
             isPersonalData = true
+          } else if (
+            chunk.type === "calendar-action" &&
+            chunk.action !== null &&
+            typeof chunk.action === "object"
+          ) {
+            // Backend M3 (Dhruvam) owns the calendar tool logic.
+            // This handler activates when the backend emits a calendar-action event.
+            calendarAction = chunk.action as CalendarActionData
           }
         }
 
         const finalMessages: ChatMessage[] = [
           ...baseMessages,
-          { ...assistantMsg, content: assistantText, is_personal_data: isPersonalData || undefined },
+          {
+            ...assistantMsg,
+            content: assistantText,
+            is_personal_data: isPersonalData || undefined,
+            calendar_action: calendarAction,
+          },
         ]
         persistMessages(threadId, finalMessages)
 

--- a/aura/lib/chat-types.ts
+++ b/aura/lib/chat-types.ts
@@ -1,8 +1,25 @@
+/**
+ * Structured data returned by the backend calendar tool when a booking
+ * or reminder is created. Populated only when chunk.type === "calendar-action"
+ * arrives in the SSE stream. Backend M3 (Dhruvam) owns the tool logic.
+ */
+export interface CalendarActionData {
+  event_title?: string
+  date?: string
+  time?: string
+  attendees?: string[]
+  status?: "confirmed" | "pending" | "failed"
+  calendar_link?: string
+  description?: string
+}
+
 export interface ChatMessage {
   role: "user" | "assistant"
   content: string
   timestamp?: number
   is_personal_data?: boolean
+  /** Set when the backend emits a calendar-action SSE event for this turn. */
+  calendar_action?: CalendarActionData
 }
 
 export interface Citation {


### PR DESCRIPTION
## Summary
Implements all tasks assigned to Manal in **AURA Status Report v6** (Frontend domain).

---

## Changes

### `FacultyDashboard.tsx` — live data wiring
- Replaced all hardcoded placeholder data with live AURA backend calls on mount
- **Today's Schedule card** — fetches via `/api/chat` → AURA RAG + `faculty_schedule` tool → skeleton loading + graceful fallback for aggregation model
- **Advisee Count card** — fetches via `/api/chat` → AURA RAG + `composite_tools.get_advisee_snapshot` → skeleton + fallback
- **Attendance card** — intentionally absent (`eCampus attendance data unavailable` — revisit when UniRP exposes endpoint)
- **Calendar card** — prompt shortcut; full booking UI activates when Backend M3 ships
- **UniRP TODO markers** added at all faculty data-fetch sites per spec

### `lib/chat-types.ts` — CalendarActionData type
- Added `CalendarActionData` interface
- Added optional `calendar_action?: CalendarActionData` on `ChatMessage`

### `hooks/use-aura-chat.ts` — SSE calendar-action handler
- Handles `chunk.type === "calendar-action"` in SSE stream parser
- Attaches payload to assistant message for downstream rendering

### `components/features/chat-v2/Message.tsx` — BookingConfirmationCard
- Renders inline when `message.calendar_action` is set (confirmed / pending / failed states)
- Shows: event title, date/time, attendees, Google Calendar link

---

## Cross-team Dependencies

| Dependency | Owner | Status |
|---|---|---|
| `faculty_schedule` backend tool | Parth (Backend) | ✅ Done |
| `composite_tools.get_advisee_snapshot` | Backend | ✅ Done |
| Calendar create/remind tool | Dhruvam (Backend M3) | ❌ Not started — card ready |
| UniRP faculty routes | TBD | ⚠️ Deferred — TODO markers added |

---

## Quality Gates
- `tsc --noEmit` — **0 errors in changed files**
- `next lint` — **✅ Passed**
