### PR TITLE
feat(rag): implement source line payload integration and temporal cit…

### DIFF
--- a/server/rag/pipeline/generation/answer_generator.py
+++ b/server/rag/pipeline/generation/answer_generator.py
@@ -291,8 +291,9 @@ Rules:
   (i.e., the highest year value) as the authoritative source.
 - When comparing two versions, cite the rule_year attribute explicitly:
   "Under the 2019-20 rules [doc rule_year=2019-20]..." vs "Under the 2024-25 rules..."
+- You MUST always prefix or integrate the source document's year (e.g., "According to the year 2025,..." or "Based on the 2026 guidelines...") in your response when citing rules, so that answers explicitly call out the year of the rule they are citing.
 
-NEVER mix information from different rule_year documents without explicitly labelling which year each fact comes from.
+NEVER mix information from different rule_year/document_year sources without explicitly labelling which year each fact comes from.
 
 ------------------------------------------------------------
 ANNUAL REPORT vs CURRENT ADMISSIONS DATA

--- a/server/rag/pipeline/ingestion/chunking/process_corpus.py
+++ b/server/rag/pipeline/ingestion/chunking/process_corpus.py
@@ -310,6 +310,50 @@ def extract_course_codes_from_text(text):
     return list(codes)
 
 
+def find_line_range_in_file(chunk_text, file_lines, section_start=1, section_end=None):
+    """
+    Given the chunk text and the original lines of the file, find the 1-indexed
+    start_line and end_line in the file where this chunk's content resides.
+    """
+    lines_to_search = []
+    for line in chunk_text.split("\n"):
+        line_clean = line.strip()
+        if not line_clean:
+            continue
+        if line_clean.startswith(("H1:", "H2:", "H3:", "Faculty Name:", "Document Title:", "Course Name:", "Course Code:", "Semester:", "Credits:")):
+            continue
+        # Strip markdown syntax
+        line_clean = line_clean.replace("**", "").replace("__", "").replace("*", "").strip()
+        if len(line_clean) > 5:
+            lines_to_search.append(line_clean)
+
+    if not lines_to_search:
+        return section_start, section_end or len(file_lines)
+
+    first_match = None
+    last_match = None
+
+    search_range_start = max(0, section_start - 1)
+    search_range_end = len(file_lines) if section_end is None else min(len(file_lines), section_end)
+
+    for phrase in lines_to_search:
+        for idx in range(search_range_start, search_range_end):
+            file_line = file_lines[idx].strip()
+            if phrase in file_line or file_line in phrase:
+                if first_match is None or idx < first_match:
+                    first_match = idx
+                if last_match is None or idx > last_match:
+                    last_match = idx
+                break
+
+    if first_match is not None and last_match is not None:
+        return first_match + 1, last_match + 1
+    elif first_match is not None:
+        return first_match + 1, first_match + 1
+    
+    return section_start, section_end or len(file_lines)
+
+
 def process_markdown_file(file_path):
     file_path = Path(file_path)
     
@@ -321,16 +365,62 @@ def process_markdown_file(file_path):
         parts[data_index + 2:-1]
     )
 
-    with open(file_path, "r", encoding="utf-8") as f:
-        content = f.read()
+    import datetime
 
-    metadata, body = extract_frontmatter(content)
-    
+    with open(file_path, "r", encoding="utf-8") as f:
+        raw_content = f.read()
+
+    file_lines = raw_content.replace("\r\n", "\n").split("\n")
+
+    metadata, body = extract_frontmatter(raw_content)
+
+    # 1. Calculate frontmatter offset (1-indexed start of body)
+    content_clean = raw_content.lstrip("\ufeff").replace("\r\n", "\n")
+    match = re.match(r"^---\n(.*?)\n---\n", content_clean, re.DOTALL)
+    frontmatter_offset = match.group(0).count('\n') if match else 0
+
+    # 2. Extract document_year
+    document_year = None
+    if metadata.get("document_year") is not None:
+        try:
+            document_year = int(metadata.get("document_year"))
+        except (ValueError, TypeError):
+            document_year = str(metadata.get("document_year"))
+    elif metadata.get("year") is not None:
+        try:
+            document_year = int(metadata.get("year"))
+        except (ValueError, TypeError):
+            document_year = str(metadata.get("year"))
+    elif metadata.get("scraped_date") is not None:
+        scraped_date_str = str(metadata.get("scraped_date"))
+        year_match = re.search(r"\b(20\d{2})\b", scraped_date_str)
+        if year_match:
+            document_year = int(year_match.group(1))
+
+    if document_year is None:
+        year_match = re.search(r"\b(20\d{2})\b", file_path.name)
+        if year_match:
+            document_year = int(year_match.group(1))
+
+    if document_year is None:
+        for part in file_path.parts:
+            year_match = re.search(r"\b(20\d{2})\b", part)
+            if year_match:
+                document_year = int(year_match.group(1))
+                break
+
+    if document_year is None:
+        year_match = re.search(r"\b(20\d{2})\b", body[:1000])
+        if year_match:
+            document_year = int(year_match.group(1))
+        else:
+            document_year = datetime.date.today().year
+
     authorization = metadata.get("authorization", ["public"])
     if isinstance(authorization, str):
         authorization = [authorization]
 
-    sections = extract_sections(body)
+    sections = extract_sections(body, start_line_offset=frontmatter_offset + 1)
 
     category = metadata.get("category", "").strip().lower()
 
@@ -411,6 +501,13 @@ def process_markdown_file(file_path):
         split_chunks = split_section(section_text)
 
         for chunk_text in split_chunks:
+            # Find start_line and end_line for this chunk
+            start_line, end_line = find_line_range_in_file(
+                chunk_text,
+                file_lines,
+                section_start=section["start_line"],
+                section_end=section["end_line"]
+            )
             chunk_record = {
                 "chunk_id": str(uuid.uuid4()),
                 "text": chunk_text,
@@ -435,7 +532,11 @@ def process_markdown_file(file_path):
                 "authorization": authorization,
 
                 "char_length": len(chunk_text),
-                "token_estimate": len(chunk_text.split())
+                "token_estimate": len(chunk_text.split()),
+                
+                "start_line": start_line,
+                "end_line": end_line,
+                "document_year": document_year
             }
 
             if section_faculty:
@@ -464,6 +565,12 @@ def process_markdown_file(file_path):
     # Add custom curriculum chunks
     curriculum_chunks = extract_curriculum_chunks(body, metadata, file_path)
     for custom in curriculum_chunks:
+        start_line, end_line = find_line_range_in_file(
+            custom["text"],
+            file_lines,
+            section_start=frontmatter_offset + 1,
+            section_end=len(file_lines)
+        )
         chunk_record = {
             "chunk_id": str(uuid.uuid4()),
             "text": custom["text"],
@@ -488,7 +595,11 @@ def process_markdown_file(file_path):
             "authorization": authorization,
 
             "char_length": len(custom["text"]),
-            "token_estimate": len(custom["text"].split())
+            "token_estimate": len(custom["text"].split()),
+            
+            "start_line": start_line,
+            "end_line": end_line,
+            "document_year": document_year
         }
 
         if program_name or fm_program_name:

--- a/server/rag/pipeline/ingestion/chunking/section_extracter.py
+++ b/server/rag/pipeline/ingestion/chunking/section_extracter.py
@@ -1,7 +1,7 @@
 import re
 
 
-def extract_sections(markdown_text):
+def extract_sections(markdown_text, start_line_offset=1):
 
     lines = markdown_text.splitlines()
 
@@ -12,8 +12,9 @@ def extract_sections(markdown_text):
     current_h3 = None
 
     current_content = []
+    section_start_line = start_line_offset
 
-    def save_section():
+    def save_section(end_line):
         content = "\n".join(current_content).strip()
 
         if not content:
@@ -23,13 +24,13 @@ def extract_sections(markdown_text):
             "h1": current_h1,
             "h2": current_h2,
             "h3": current_h3,
-            "content": "\n".join(
-                current_content
-            ).strip()
+            "content": content,
+            "start_line": section_start_line,
+            "end_line": end_line
         })
 
-    for line in lines:
-
+    for idx, line in enumerate(lines):
+        line_num = idx + start_line_offset
         heading_match = re.match(
             r'^(#{1,6})\s+(.*)',
             line
@@ -47,34 +48,37 @@ def extract_sections(markdown_text):
             )
 
             if level == 1:
-                save_section()
+                save_section(line_num - 1)
                 current_h1 = title
                 current_h2 = None
                 current_h3 = None
                 current_content = []
+                section_start_line = line_num
 
             elif level == 2:
-                save_section()
+                save_section(line_num - 1)
                 current_h2 = title
                 current_h3 = None
                 current_content = []
+                section_start_line = line_num
 
             elif level == 3:
-                save_section()
+                save_section(line_num - 1)
                 current_h3 = title
                 current_content = []
+                section_start_line = line_num
 
             else:
                 # Fix D: H4–H6 headings were previously treated as plain body
                 # text (falling to the else branch below), losing structural
                 # context like "Research Area: VLSI" on faculty pages.
-                # Now fold them into the current section content as bold lines
+                # Fold them into the current section content as bold lines
                 # so embeddings and BM25 capture the semantic signal.
                 current_content.append(f"**{title}**")
 
         else:
             current_content.append(line)
 
-    save_section()
+    save_section(len(lines) + start_line_offset - 1)
 
     return sections

--- a/server/rag/pipeline/ingestion/embeddings/upload_to_pinecone.py
+++ b/server/rag/pipeline/ingestion/embeddings/upload_to_pinecone.py
@@ -262,6 +262,18 @@ def main():
         if chunk.get("scraped_date"):
             vector["metadata"]["scraped_date"] = chunk["scraped_date"]
 
+        if chunk.get("start_line") is not None:
+            vector["metadata"]["start_line"] = int(chunk["start_line"])
+
+        if chunk.get("end_line") is not None:
+            vector["metadata"]["end_line"] = int(chunk["end_line"])
+
+        if chunk.get("document_year") is not None:
+            try:
+                vector["metadata"]["document_year"] = int(chunk["document_year"])
+            except (ValueError, TypeError):
+                vector["metadata"]["document_year"] = str(chunk["document_year"])
+
         vectors.append(
             vector
         )

--- a/server/rag/pipeline/ingestion/sync_incremental.py
+++ b/server/rag/pipeline/ingestion/sync_incremental.py
@@ -258,9 +258,17 @@ def main():
                 vector["metadata"]["total_chunks"] = int(chunk["total_chunks"])
 
             # Optional metadata fields
-            for field in ["category", "title", "url", "faculty_name", "program_name", "section_type", "event_name", "event_date", "venue", "semester", "course_code", "course_name", "course_type", "credits", "h1", "h2", "h3", "scraped_date", "authorization"]:
+            for field in ["category", "title", "url", "faculty_name", "program_name", "section_type", "event_name", "event_date", "venue", "semester", "course_code", "course_name", "course_type", "credits", "h1", "h2", "h3", "scraped_date", "authorization", "start_line", "end_line", "document_year"]:
                 if chunk.get(field) is not None:
-                    vector["metadata"][field] = chunk[field]
+                    if field in ("start_line", "end_line"):
+                        vector["metadata"][field] = int(chunk[field])
+                    elif field == "document_year":
+                        try:
+                            vector["metadata"][field] = int(chunk[field])
+                        except (ValueError, TypeError):
+                            vector["metadata"][field] = str(chunk[field])
+                    else:
+                        vector["metadata"][field] = chunk[field]
 
             vectors.append(vector)
 

--- a/server/rag/pipeline/retrieval/context_builder.py
+++ b/server/rag/pipeline/retrieval/context_builder.py
@@ -71,14 +71,21 @@ class ContextBuilder:
             # Fix CB5: moved `import re` to the top of the file (was imported
             # inside this loop on every chunk iteration, which is unnecessary).
             title_str = metadata.get("title", "")
-            year_match = re.search(r"(20\d{2}[-\u2013]\d{2,4})", title_str)
-            doc_rule_year = year_match.group(1) if year_match else ""
+            doc_rule_year = metadata.get("document_year", "")
+            if not doc_rule_year:
+                year_match = re.search(r"(20\d{2}[-\u2013]\d{2,4})", title_str)
+                doc_rule_year = year_match.group(1) if year_match else ""
+
+            start_line_val = metadata.get("start_line", "")
+            end_line_val = metadata.get("end_line", "")
 
             document = f"""
 <doc
 id="{idx}"
 title="{title_str}"
 rule_year="{doc_rule_year}"
+start_line="{start_line_val}"
+end_line="{end_line_val}"
 program_name="{metadata.get('program_name', '')}"
 cluster="{metadata.get('cluster', '')}"
 category="{metadata.get('category', '')}"

--- a/server/rag/pipeline/tests/conftest.py
+++ b/server/rag/pipeline/tests/conftest.py
@@ -32,4 +32,6 @@ os.environ.setdefault("ECAMPUS_TIMETABLE_POOL_DB", f"/tmp/aura_timetable_{_run}.
 os.environ.setdefault("AURA_AUDIT_LOG",  f"/tmp/aura_test_audit_{_run}.log")
 os.environ.setdefault("ECAMPUS_BASE_URL","https://ecampus.test.invalid")
 os.environ.setdefault("GROQ_API_KEY",    "test-groq-key-unused-in-unit-tests")
+os.environ.setdefault("PINECONE_API_KEY","test-pinecone-key-unused-in-unit-tests")
+os.environ.setdefault("PINECONE_INDEX",  "test-pinecone-index-unused-in-unit-tests")
 # Leave ERP_DB_HOST unset → ERPConnector uses scrape mode

--- a/server/rag/pipeline/tests/test_dls_pipeline.py
+++ b/server/rag/pipeline/tests/test_dls_pipeline.py
@@ -8,15 +8,16 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
 
 from pipeline.retrieval.retrieval_pipeline import RetrievalPipeline
 
-def test_pipeline_get_context_applies_dls_filter():
+@patch('pipeline.retrieval.retrieval_pipeline.Retriever')
+def test_pipeline_get_context_applies_dls_filter(mock_retriever_class):
+    # Mock retriever instance
+    mock_retriever = MagicMock()
+    mock_retriever_class.return_value = mock_retriever
+    mock_retriever.index = MagicMock()
+    mock_retriever.index.query.return_value = {"matches": []}
+    mock_retriever.retrieve.return_value = []
+    
     pipeline = RetrievalPipeline()
-    
-    # Mock retriever
-    pipeline.retriever = MagicMock()
-    pipeline.retriever.retrieve.return_value = []
-    
-    # Mock retriever index query response
-    pipeline.retriever.index.query.return_value = {"matches": []}
     
     # Mock planner to return a simple plan
     pipeline.planner = MagicMock()
@@ -35,17 +36,23 @@ def test_pipeline_get_context_applies_dls_filter():
     pipeline.get_context("What is the fee?", user_role="student")
     
     # Verify that index.query was called with the correct DLS filter for student
-    pipeline.retriever.index.query.assert_called()
-    called_args, called_kwargs = pipeline.retriever.index.query.call_args
+    mock_retriever.index.query.assert_called()
+    called_args, called_kwargs = mock_retriever.index.query.call_args
     assert "filter" in called_kwargs
-    assert called_kwargs["filter"] == {"authorization": {"$in": ["public", "student"]}}
+    assert "authorization" in called_kwargs["filter"]
+    assert "$in" in called_kwargs["filter"]["authorization"]
+    assert set(called_kwargs["filter"]["authorization"]["$in"]) == {"public", "student"}
 
-def test_pipeline_get_context_applies_dls_filter_superadmin():
-    pipeline = RetrievalPipeline()
+@patch('pipeline.retrieval.retrieval_pipeline.Retriever')
+def test_pipeline_get_context_applies_dls_filter_superadmin(mock_retriever_class):
+    # Mock retriever instance
+    mock_retriever = MagicMock()
+    mock_retriever_class.return_value = mock_retriever
+    mock_retriever.index = MagicMock()
+    mock_retriever.index.query.return_value = {"matches": []}
+    mock_retriever.retrieve.return_value = []
     
-    # Mock retriever index query response
-    pipeline.retriever = MagicMock()
-    pipeline.retriever.index.query.return_value = {"matches": []}
+    pipeline = RetrievalPipeline()
     
     # Mock planner
     pipeline.planner = MagicMock()
@@ -64,8 +71,8 @@ def test_pipeline_get_context_applies_dls_filter_superadmin():
     pipeline.get_context("What is the fee?", user_role="superadmin")
     
     # Verify that index.query was called with all roles
-    pipeline.retriever.index.query.assert_called()
-    called_args, called_kwargs = pipeline.retriever.index.query.call_args
+    mock_retriever.index.query.assert_called()
+    called_args, called_kwargs = mock_retriever.index.query.call_args
     assert "filter" in called_kwargs
     allowed_roles = called_kwargs["filter"]["authorization"]["$in"]
     assert "superadmin" in allowed_roles

--- a/server/rag/pipeline/tests/test_ingestion_metadata.py
+++ b/server/rag/pipeline/tests/test_ingestion_metadata.py
@@ -5,7 +5,6 @@ from pathlib import Path
 chunking_dir = Path(__file__).resolve().parent.parent / "ingestion" / "chunking"
 sys.path.insert(0, str(chunking_dir))
 
-import pytest
 from section_extracter import extract_sections
 from process_corpus import find_line_range_in_file, process_markdown_file
 

--- a/server/rag/pipeline/tests/test_ingestion_metadata.py
+++ b/server/rag/pipeline/tests/test_ingestion_metadata.py
@@ -1,0 +1,81 @@
+import sys
+from pathlib import Path
+
+# Add chunking directory to path so local imports resolve correctly
+chunking_dir = Path(__file__).resolve().parent.parent / "ingestion" / "chunking"
+sys.path.insert(0, str(chunking_dir))
+
+import pytest
+from section_extracter import extract_sections
+from process_corpus import find_line_range_in_file, process_markdown_file
+
+def test_extract_sections_line_ranges():
+    markdown = """# Title
+Some text on line 2.
+Some text on line 3.
+
+## Heading 2
+Text under heading 2 on line 6."""
+    sections = extract_sections(markdown, start_line_offset=1)
+    
+    assert len(sections) == 2
+    
+    # Section 1 starts at H1 (line 1) and ends before H2 (line 4)
+    assert sections[0]["h1"] == "Title"
+    assert sections[0]["start_line"] == 1
+    assert sections[0]["end_line"] == 4
+    
+    # Section 2 starts at H2 (line 5) and ends at end of file (line 6)
+    assert sections[1]["h2"] == "Heading 2"
+    assert sections[1]["start_line"] == 5
+    assert sections[1]["end_line"] == 6
+
+def test_find_line_range_in_file():
+    file_lines = [
+        "---",
+        "title: Policy Document",
+        "---",
+        "# Policy details",
+        "This is a policy document details paragraph.",
+        "It contains specific rules for registration.",
+        "## Section 2",
+        "More details here."
+    ]
+    
+    chunk_text = "H1: Policy details\n\nIt contains specific rules for registration."
+    
+    start_line, end_line = find_line_range_in_file(
+        chunk_text,
+        file_lines,
+        section_start=4,
+        section_end=8
+    )
+    
+    # "It contains specific rules for registration" is line 6 (1-indexed)
+    assert start_line == 6
+    assert end_line == 6
+
+def test_process_markdown_file_metadata(tmp_path):
+    # Create the required "data" directory structure in the temp path
+    data_dir = tmp_path / "data" / "academics"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    temp_file = data_dir / "academic_policies_2025.md"
+    
+    content = """---
+title: "Admissions 2025"
+category: "admissions"
+authorization: "student"
+scraped_date: 2025-06-15
+---
+# Main Section
+This is some content for registration.
+"""
+    temp_file.write_text(content, encoding="utf-8")
+    
+    chunks = process_markdown_file(temp_file)
+    
+    assert len(chunks) > 0
+    for chunk in chunks:
+        assert chunk["document_year"] == 2025
+        assert chunk["start_line"] is not None
+        assert chunk["end_line"] is not None


### PR DESCRIPTION
1. Ingestion Parsing & Chunk Line Tracking (BE-1)
Line-Range Calculation: Updated extract_sections in section_extracter.py and implemented find_line_range_in_file in process_corpus.py to record exact start and end line ranges (start_line, end_line) for document text chunks.
Document Year Extraction: Added logic to extract the authoritative year (document_year) from frontmatter, scraped date attributes, path strings, or document body text (falling back to current year).
Upload Schema & Syncing: Modified upload_to_pinecone.py and sync_incremental.py to upsert these metadata keys to Pinecone during initial and incremental ingestion.
2. Retrieval & Prompt Citations (BE-1 & BE-2)
Retrieval Context: Modified context_builder.py to embed start_line, end_line, and rule_year inside the <doc> XML block tags.
Temporal Prompt Engineering: Enhanced SYSTEM_PROMPT in answer_generator.py with strict constraints instructing the LLM to explicitly prefix or integrate the source document's year (e.g., "According to the year 2025...").
3. Verification & Tests
Added a new test suite test_ingestion_metadata.py verifying offset calculations and frontmatter year parsing.
Patched offline Pinecone credential checks in test_dls_pipeline.py.