### PR TITLE
docs(git): redirect PRs to pwa-demo integration branch

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+<!--
+  Base branch: pwa-demo  (NOT main)
+  All feature PRs merge into `pwa-demo` for demo purposes.
+  `main` is production and is promoted from `pwa-demo` by the team leads.
+-->
+
+## Summary
+
+<!-- What does this PR change and why? -->
+
+## Test Plan
+
+<!-- How was this verified? Commands run, cases covered. -->
+
+## Screenshots
+
+<!-- Required for UI changes. Delete if not applicable. -->
+
+## Checklist
+
+- [ ] Base branch is **`pwa-demo`**
+- [ ] `pnpm lint` and `pnpm type-check` pass
+- [ ] Linked the related issue (`Closes #<n>`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,8 +121,8 @@ See `AGENTS.md` for the full agent behaviour ruleset.
 
 | Pattern | Purpose |
 |---------|---------|
-| `main` | Production-ready, protected. No direct pushes. |
-| `dev` | Integration branch. All PRs target `dev`. |
+| `main` | Production-ready, protected. Promoted from `pwa-demo`; no direct pushes. |
+| `pwa-demo` | Default & integration branch for the demo. **All PRs target `pwa-demo`.** Protected. |
 | `<name>/<feature>` | Personal feature branches (e.g. `aditya/auth-flow`) |
 | `hotfix/<issue>` | Critical fixes that go directly to `main` via fast PR |
 
@@ -144,14 +144,14 @@ Examples:
 
 - Subject line ≤ 72 characters.
 - Body optional, but required for `fix` commits — explain the root cause.
-- No "WIP" commits on `dev` or `main`.
+- No "WIP" commits on `pwa-demo` or `main`.
 
 ### Pull Requests
 
 - PR title mirrors the commit format.
 - Fill the PR template: summary, test plan, screenshots for UI changes.
-- Minimum 1 review approval before merge to `dev`; 2 for `main`.
-- Squash-merge feature branches into `dev`. Merge commits for `dev` → `main`.
+- Minimum 1 review approval before merge to `pwa-demo`; 2 for `main`.
+- Squash-merge feature branches into `pwa-demo`. Merge commits for `pwa-demo` → `main`.
 - Link the related GitHub issue (`Closes #<n>`).
 
 ---


### PR DESCRIPTION
## Summary

Documents the workflow change: **all feature PRs now target `pwa-demo`** (the new default branch) for demo purposes. `main` remains production and is promoted from `pwa-demo` by the leads.

Changes already applied to the repo:
- Created `pwa-demo` from `main` and set it as the **default branch** (new PRs auto-target it).
- Extended the branch-protection ruleset to cover both `pwa-demo` and `main`.
- Retargeted open PRs #150, #128, #127 from `main` to `pwa-demo`.

This PR:
- Updates `CLAUDE.md` Git workflow (branch table + PR rules) to reference `pwa-demo` instead of the non-existent `dev`.
- Adds `.github/pull_request_template.md` pinning the base branch and required checks.

## Test Plan

Docs-only change. Verified default branch = `pwa-demo` and ruleset covers `~DEFAULT_BRANCH` + `refs/heads/main`.

## Screenshots

N/A