### PR TITLE
Restrict Google sign-in to @dau.ac.in and add anonymous guest access

### DIFF
--- a/aura/app/api/chat/route.ts
+++ b/aura/app/api/chat/route.ts
@@ -1,4 +1,6 @@
 import { getServerSession } from "next-auth"
+import { cookies } from "next/headers"
+import { randomUUID } from "crypto"
 import { z } from "zod"
 
 import {
@@ -10,6 +12,13 @@ import { authOptions } from "@/lib/auth/options"
 import { signInternalJwt } from "@/lib/auth/internal-jwt"
 
 export const maxDuration = 60
+
+// Cookie identifying an anonymous guest browser (no Google sign-in). It
+// carries no PII — just a random id — and lets the backend's 10/day quota
+// (see server/rag/pipeline/rate_limiter.py) key on a stable per-browser
+// identity instead of resetting on every request.
+const GUEST_COOKIE = "aura-guest-id"
+const GUEST_COOKIE_MAX_AGE = 60 * 60 * 24 * 365 // 1 year
 
 const historyTurnSchema = z.object({
   role: z.enum(["user", "assistant"]),
@@ -84,8 +93,39 @@ function normaliseSource(
 
 export async function POST(req: Request) {
   const session = await getServerSession(authOptions)
-  if (!session?.user?.erpId || !session.user.role) {
-    return new Response("Unauthorized", { status: 401 })
+
+  // Signed-in @dau.ac.in accounts use their real erpId/role (unlimited
+  // quota, enforced server-side). Everyone else is treated as an
+  // anonymous guest identified by a long-lived cookie, capped at 10
+  // questions/day.
+  let identity: {
+    role: "student" | "faculty" | "admin" | "guest"
+    erpId: string
+    department?: string
+    email?: string
+  }
+
+  if (session?.user?.erpId && session.user.role) {
+    identity = {
+      role: session.user.role,
+      erpId: session.user.erpId,
+      department: session.user.department,
+      email: session.user.email ?? undefined,
+    }
+  } else {
+    const cookieStore = await cookies()
+    let guestId = cookieStore.get(GUEST_COOKIE)?.value
+    if (!guestId || guestId.length > 64) {
+      guestId = `GUEST-${randomUUID()}`
+      cookieStore.set(GUEST_COOKIE, guestId, {
+        httpOnly: true,
+        sameSite: "lax",
+        secure: process.env.NODE_ENV === "production",
+        path: "/",
+        maxAge: GUEST_COOKIE_MAX_AGE,
+      })
+    }
+    identity = { role: "guest", erpId: guestId }
   }
 
   let body: unknown
@@ -101,10 +141,10 @@ export async function POST(req: Request) {
   }
 
   const internalToken = signInternalJwt({
-    role: session.user.role,
-    erpId: session.user.erpId,
-    department: session.user.department,
-    email: session.user.email ?? undefined,
+    role: identity.role,
+    erpId: identity.erpId,
+    department: identity.department,
+    email: identity.email,
   })
 
   // Map studentProfile → userProfile for FastAPI; cap history for cost/latency.

--- a/aura/app/login/page.tsx
+++ b/aura/app/login/page.tsx
@@ -27,7 +27,7 @@ function LoginCard() {
   if (errorParam === "NotRegistered") {
     errorMsg = "Your DAU account is not yet registered in AURA. Contact the administrator."
   } else if (errorParam === "DomainNotAllowed") {
-    errorMsg = "Access restricted. You must log in with a @dau.ac.in or @daiict.ac.in email address."
+    errorMsg = "Access restricted. Sign in requires an official @dau.ac.in email address. Use \"Continue as Guest\" instead."
   } else if (errorParam) {
     errorMsg = "Authentication failed. Please try again."
   }
@@ -97,7 +97,23 @@ function LoginCard() {
       </button>
 
       <p className="mt-4 text-center text-xs text-neutral-400">
-        Must be an official @dau.ac.in or @daiict.ac.in email address.
+        Must be an official @dau.ac.in email address.
+      </p>
+
+      <div className="mt-5 flex items-center gap-3 text-[11px] text-neutral-600">
+        <div className="h-px flex-1 bg-theme-gray-light" />
+        or
+        <div className="h-px flex-1 bg-theme-gray-light" />
+      </div>
+
+      <a
+        href="/"
+        className="mt-5 flex w-full cursor-pointer items-center justify-center rounded-xl border border-theme-gray-lighter bg-transparent py-3 text-sm font-medium text-neutral-300 transition-all hover:border-neutral-500 hover:text-white"
+      >
+        Continue as Guest
+      </a>
+      <p className="mt-2 text-center text-xs text-neutral-500">
+        Guests get 10 questions/day. Sign in for unlimited access.
       </p>
 
       {/* Development Demo Mode - always shown in dev build */}

--- a/aura/app/login/page.tsx
+++ b/aura/app/login/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, Suspense, useEffect } from "react"
+import Link from "next/link"
 import { signIn } from "next-auth/react"
 import { useSearchParams } from "next/navigation"
 import { Sparkles, Loader2, GraduationCap, BookOpen, AlertCircle, Shield } from "lucide-react"
@@ -106,12 +107,12 @@ function LoginCard() {
         <div className="h-px flex-1 bg-theme-gray-light" />
       </div>
 
-      <a
+      <Link
         href="/"
         className="mt-5 flex w-full cursor-pointer items-center justify-center rounded-xl border border-theme-gray-lighter bg-transparent py-3 text-sm font-medium text-neutral-300 transition-all hover:border-neutral-500 hover:text-white"
       >
         Continue as Guest
-      </a>
+      </Link>
       <p className="mt-2 text-center text-xs text-neutral-500">
         Guests get 10 questions/day. Sign in for unlimited access.
       </p>

--- a/aura/components/features/chat-ui/Composer.tsx
+++ b/aura/components/features/chat-ui/Composer.tsx
@@ -54,7 +54,11 @@ export function Composer({
   }, [])
 
   const isUnauthenticated = status === "unauthenticated"
-  const canSend = inputText.trim().length > 0 && !loading && !isRecording && !isUnauthenticated
+  // Guests (unauthenticated) can send until their daily quota hits 0.
+  // Signed-in @dau.ac.in accounts have unlimited quota, so remainingQuota
+  // is always null for them and this never blocks sending.
+  const quotaExhausted = remainingQuota === 0
+  const canSend = inputText.trim().length > 0 && !loading && !isRecording && !quotaExhausted
   const nearLimit = inputText.length >= MAX_CHARS * 0.9
   const atLimit = inputText.length >= MAX_CHARS
   const role = (session?.user?.role as string) || ""
@@ -100,15 +104,23 @@ export function Composer({
           variant === "docked" && "mx-auto max-w-3xl px-4 pb-3 md:pb-4",
         )}
       >
-        {isUnauthenticated ? (
+        {quotaExhausted ? (
           <div className="flex flex-col items-center justify-center rounded-[26px] border border-theme-gray-light bg-theme-gray/80 px-4 py-7 text-center shadow-[0_18px_50px_-24px_rgba(0,0,0,0.9)] backdrop-blur-xl">
-            <p className="mb-3.5 text-sm text-neutral-400">Sign in to start chatting with AURA</p>
-            <a
-              href="/login"
-              className="inline-flex h-9 items-center justify-center gap-1.5 rounded-full bg-gradient-to-r from-theme-red to-theme-yellow px-5 text-sm font-semibold text-black transition-all hover:brightness-110 active:scale-[0.98]"
-            >
-              Sign in
-            </a>
+            <p className="mb-3.5 text-sm text-neutral-400">
+              {isUnauthenticated
+                ? "You've used all your free questions for today."
+                : "Question limit reached."}
+            </p>
+            {isUnauthenticated ? (
+              <a
+                href="/login"
+                className="inline-flex h-9 items-center justify-center gap-1.5 rounded-full bg-gradient-to-r from-theme-red to-theme-yellow px-5 text-sm font-semibold text-black transition-all hover:brightness-110 active:scale-[0.98]"
+              >
+                Sign in with @dau.ac.in for unlimited access
+              </a>
+            ) : (
+              <p className="text-xs text-neutral-500">Please try again tomorrow.</p>
+            )}
           </div>
         ) : (
           <div
@@ -233,7 +245,7 @@ export function Composer({
           </div>
         )}
 
-        {!isUnauthenticated ? (
+        {!quotaExhausted ? (
           <p className="mt-2.5 text-center text-[11px] text-neutral-600">
             AURA can make mistakes. Verify important info.
           </p>

--- a/aura/hooks/use-aura-chat.ts
+++ b/aura/hooks/use-aura-chat.ts
@@ -128,48 +128,53 @@ export function useAuraChat() {
   const [studentProfile, setStudentProfile] = useState<StudentProfile>(DEFAULT_PROFILE)
   const [remainingQuota, setRemainingQuotaState] = useState<number | null>(null)
   const [hasHydrated, setHasHydrated] = useState(false)
-  const { data: session } = useSession()
+  const { data: session, status: sessionStatus } = useSession()
+
+  // Guest quota policy: signed-in @dau.ac.in accounts (student/faculty/admin)
+  // are unlimited — the backend never returns a limit for them, so we show
+  // no counter. Anonymous guests (no session at all) get 10 questions/day;
+  // the real enforcement lives server-side against a cookie-scoped
+  // anonymous id, this is just a local mirror for the UI counter.
+  const GUEST_DAILY_QUOTA = 10
+  const GUEST_QUOTA_KEY = "aura-quota-guest"
 
   useEffect(() => {
+    if (sessionStatus === "loading") return
     if (session?.user) {
-      const email = session.user.email || 'guest'
-      const role = session.user.role || 'guest'
-      const maxQuota = role === 'guest' ? 3 : 5
-      const date = new Date().toISOString().split('T')[0]
-      const key = `aura-quota-${email}`
-      
-      try {
-        const stored = localStorage.getItem(key)
-        if (stored) {
-          const parsed = JSON.parse(stored)
-          if (parsed.date === date) {
-            setRemainingQuotaState(Math.max(0, maxQuota - parsed.count))
-          } else {
-            setRemainingQuotaState(maxQuota)
-            localStorage.setItem(key, JSON.stringify({ date, count: 0 }))
-          }
+      setRemainingQuotaState(null)
+      return
+    }
+    const maxQuota = GUEST_DAILY_QUOTA
+    const date = new Date().toISOString().split('T')[0]
+    const key = GUEST_QUOTA_KEY
+
+    try {
+      const stored = localStorage.getItem(key)
+      if (stored) {
+        const parsed = JSON.parse(stored)
+        if (parsed.date === date) {
+          setRemainingQuotaState(Math.max(0, maxQuota - parsed.count))
         } else {
           setRemainingQuotaState(maxQuota)
           localStorage.setItem(key, JSON.stringify({ date, count: 0 }))
         }
-      } catch {
+      } else {
         setRemainingQuotaState(maxQuota)
+        localStorage.setItem(key, JSON.stringify({ date, count: 0 }))
       }
-    } else {
-      setRemainingQuotaState(null)
+    } catch {
+      setRemainingQuotaState(maxQuota)
     }
-  }, [session])
+  }, [session, sessionStatus])
 
   const decrementQuota = useCallback(() => {
     setRemainingQuotaState(prev => {
       if (prev === null) return null;
       const newVal = Math.max(0, prev - 1)
-      if (session?.user) {
-        const email = session.user.email || 'guest'
-        const role = session.user.role || 'guest'
-        const maxQuota = role === 'guest' ? 3 : 5
+      if (!session?.user) {
+        const maxQuota = GUEST_DAILY_QUOTA
         const date = new Date().toISOString().split('T')[0]
-        const key = `aura-quota-${email}`
+        const key = GUEST_QUOTA_KEY
         try {
           localStorage.setItem(key, JSON.stringify({ date, count: maxQuota - newVal }))
         } catch {}

--- a/aura/lib/auth/options.ts
+++ b/aura/lib/auth/options.ts
@@ -157,11 +157,12 @@ export const authOptions: NextAuthOptions = {
     async signIn({ user, account }) {
       if (account?.provider === "google") {
         const email = user.email || ""
-        if (!email.endsWith("@dau.ac.in") && !email.endsWith("@daiict.ac.in")) {
-          user.role = "guest"
-          user.erpId = "GUEST"
-          user.department = "GUEST"
-          return true
+        // Only official @dau.ac.in accounts may sign in. Anyone else
+        // (including personal Gmail addresses) should use the anonymous
+        // guest chat instead — see the "Continue as Guest" option on
+        // /login and the anonymous cookie flow in app/api/chat/route.ts.
+        if (!email.endsWith("@dau.ac.in")) {
+          return "/login?error=DomainNotAllowed"
         }
 
         try {

--- a/aura/tests/auth.test.tsx
+++ b/aura/tests/auth.test.tsx
@@ -10,8 +10,8 @@ vi.mock('next-auth/react', () => ({
   useSession: vi.fn(),
 }))
 
-describe('Domain detection (guest vs DAU)', () => {
-  it('assigns guest role to non-DAU emails', async () => {
+describe('Domain restriction (only @dau.ac.in may sign in)', () => {
+  it('rejects non-DAU emails instead of signing them in as guest', async () => {
     const user = { email: 'test@gmail.com' } as User & { role?: string }
     const account = { provider: 'google' } as Account
     const signIn = authOptions.callbacks?.signIn
@@ -25,13 +25,16 @@ describe('Domain detection (guest vs DAU)', () => {
       credentials: undefined,
     })
 
-    expect(result).toBe(true)
-    expect(user.role).toBe('guest')
+    // Non-@dau.ac.in Google accounts (including @daiict.ac.in and personal
+    // Gmail) are redirected to the login page instead of being let in as
+    // guest — guest access is now anonymous/no-login only.
+    expect(result).toBe('/login?error=DomainNotAllowed')
+    expect(user.role).toBeUndefined()
   })
 })
 
-describe('Unauthenticated Composer rendering', () => {
-  it('renders "Sign in to start chatting with AURA" when unauthenticated', () => {
+describe('Unauthenticated (guest) Composer rendering', () => {
+  it('lets a guest with quota remaining type and send normally', () => {
     vi.mocked(useSession).mockReturnValue({
       data: null,
       status: 'unauthenticated',
@@ -47,11 +50,39 @@ describe('Unauthenticated Composer rendering', () => {
         isTranscribing={false}
         onSend={vi.fn()}
         onMicClick={vi.fn()}
+        remainingQuota={10}
       />
     )
 
-    expect(screen.getByText('Sign in to start chatting with AURA')).toBeInTheDocument()
-    expect(screen.getByText('Sign in')).toBeInTheDocument()
+    // Guests get a normal composer, not a sign-in wall — quota is enforced
+    // separately (see server/rag/pipeline/rate_limiter.py), not by blocking
+    // input outright.
+    expect(screen.getByLabelText('Message AURA')).toBeInTheDocument()
+    expect(screen.getByText('10 messages left')).toBeInTheDocument()
+  })
+
+  it('prompts a guest to sign in once their daily quota is exhausted', () => {
+    vi.mocked(useSession).mockReturnValue({
+      data: null,
+      status: 'unauthenticated',
+      update: vi.fn(),
+    })
+
+    render(
+      <Composer
+        inputText=""
+        setInputText={vi.fn()}
+        loading={false}
+        isRecording={false}
+        isTranscribing={false}
+        onSend={vi.fn()}
+        onMicClick={vi.fn()}
+        remainingQuota={0}
+      />
+    )
+
+    expect(screen.getByText("You've used all your free questions for today.")).toBeInTheDocument()
+    expect(screen.getByText('Sign in with @dau.ac.in for unlimited access')).toBeInTheDocument()
   })
 })
 
@@ -62,13 +93,12 @@ describe('useAuraChat 429 handling', () => {
     global.fetch = vi.fn()
   })
 
-  it('handles 429 error and updates remainingQuota', async () => {
+  it('handles 429 error and updates remainingQuota for a guest', async () => {
+    // No session at all — anonymous guest, tracked via the local
+    // "aura-quota-guest" mirror of the server-enforced 10/day cookie quota.
     vi.mocked(useSession).mockReturnValue({
-      data: {
-        user: { email: 'student@dau.ac.in', role: 'student', erpId: '123' },
-        expires: '9999-12-31T23:59:59.999Z',
-      },
-      status: 'authenticated',
+      data: null,
+      status: 'unauthenticated',
       update: vi.fn(),
     })
 
@@ -83,8 +113,8 @@ describe('useAuraChat 429 handling', () => {
 
     const { result } = renderHook(() => useAuraChat())
 
-    // Initial quota for student should be 5
-    expect(result.current.remainingQuota).toBe(5)
+    // Initial quota for an anonymous guest should be 10
+    expect(result.current.remainingQuota).toBe(10)
 
     // Send a message to trigger fetch
     await act(async () => {
@@ -94,5 +124,21 @@ describe('useAuraChat 429 handling', () => {
     // After 429, quota should be 0 and errorMessage should be set
     expect(result.current.remainingQuota).toBe(0)
     expect(result.current.errorMessage).toContain("Question limit reached")
+  })
+
+  it('shows no quota limit for a signed-in @dau.ac.in account', async () => {
+    vi.mocked(useSession).mockReturnValue({
+      data: {
+        user: { email: 'student@dau.ac.in', role: 'student', erpId: '123' },
+        expires: '9999-12-31T23:59:59.999Z',
+      },
+      status: 'authenticated',
+      update: vi.fn(),
+    })
+
+    const { result } = renderHook(() => useAuraChat())
+
+    // Verified DAU accounts are unlimited — no counter shown.
+    expect(result.current.remainingQuota).toBeNull()
   })
 })

--- a/server/rag/pipeline/rate_limiter.py
+++ b/server/rag/pipeline/rate_limiter.py
@@ -1,8 +1,12 @@
 """
-Question quota enforcement — v7 policy: 3 questions/day for guest accounts,
-5 questions/day for DAU accounts (student/faculty/admin), keyed by the
-signed-in Google account (email claim in the internal JWT, since guest
-users all share erp_id="GUEST" and can't be distinguished by erp_id alone).
+Question quota enforcement — v8 policy: guests (no sign-in — each browser
+gets an anonymous erp_id minted by Next.js and stored in a cookie) get
+10 questions/day. Verified @dau.ac.in accounts (student/faculty/admin) have
+unlimited quota, since sign-in itself already confirms institutional
+identity via Google Workspace + /internal/resolve-identity.
+
+Guests are keyed by the anonymous erp_id claim in the internal JWT (there is
+no email for a guest). Signed-in users are keyed by email when present.
 
 Uses Redis when REDIS_URL is set (shared across workers); otherwise an
 in-memory store for single-process dev/tests.
@@ -16,11 +20,12 @@ from typing import Optional, Protocol
 
 QUOTA_WINDOW_SECONDS = 24 * 60 * 60  # 24h rolling window
 
-QUOTA_LIMITS = {
-    "guest": 3,
-    "student": 5,
-    "faculty": 5,
-    "admin": 5,
+# None == unlimited (no quota check performed at all).
+QUOTA_LIMITS: dict[str, Optional[int]] = {
+    "guest": 10,
+    "student": None,
+    "faculty": None,
+    "admin": None,
 }
 
 
@@ -128,17 +133,22 @@ def reset_store_for_tests(store: Optional[QuotaStore] = None) -> None:
     _store = store if store is not None else InMemoryQuotaStore()
 
 
-def enforce_quota(quota_key: str, role: str) -> int:
+def enforce_quota(quota_key: str, role: str) -> Optional[int]:
     """
     Raises QuotaExceeded if the caller has hit their daily limit; otherwise
-    records this question and returns the remaining count. `quota_key`
-    should be the signed-in Google account email — never erp_id, since all
-    guests share erp_id="GUEST".
+    records this question and returns the remaining count. Returns None
+    (and records nothing) for roles with an unlimited quota. `quota_key` is
+    the guest's anonymous erp_id, or the signed-in @dau.ac.in email for
+    verified accounts.
     """
     limit = QUOTA_LIMITS.get(role, QUOTA_LIMITS["guest"])
+    if limit is None:
+        return None
     return _store.check_and_increment(quota_key, limit)
 
 
-def peek_remaining(quota_key: str, role: str) -> int:
+def peek_remaining(quota_key: str, role: str) -> Optional[int]:
     limit = QUOTA_LIMITS.get(role, QUOTA_LIMITS["guest"])
+    if limit is None:
+        return None
     return _store.remaining(quota_key, limit)

--- a/server/rag/pipeline/tests/test_quota_enforcement.py
+++ b/server/rag/pipeline/tests/test_quota_enforcement.py
@@ -1,6 +1,6 @@
-# v7 regression: question quota enforcement (3/day guest, 5/day DAU).
-# Tests pipeline.rate_limiter directly (the FastAPI /chat endpoint just calls
-# test_wellness_guardrail.py.
+# v8 regression: question quota enforcement — 10/day for anonymous guests
+# (no Google sign-in, identified by a cookie-scoped erp_id), unlimited for
+# verified @dau.ac.in accounts (student/faculty/admin).
 
 import sys
 from pathlib import Path
@@ -22,32 +22,31 @@ def setup_function(_):
     # would otherwise leak state between tests.
     reset_store_for_tests(InMemoryQuotaStore())
     rate_limiter_module.QUOTA_LIMITS = {
-        "guest": 3,
-        "student": 5,
-        "faculty": 5,
-        "admin": 5,
+        "guest": 10,
+        "student": None,
+        "faculty": None,
+        "admin": None,
     }
 
 
-# ── Guest quota tests (limit = 3) ────────────────────────────────────────────
+# ── Guest quota tests (limit = 10) ───────────────────────────────────────────
 
-def test_guest_gets_3_questions_then_429():
-    key = "guest-user@gmail.com"
-    assert enforce_quota(key, "guest") == 2
-    assert enforce_quota(key, "guest") == 1
-    assert enforce_quota(key, "guest") == 0
+def test_guest_gets_10_questions_then_429():
+    key = "GUEST-anon-1"
+    for expected_remaining in range(9, -1, -1):
+        assert enforce_quota(key, "guest") == expected_remaining
     try:
         enforce_quota(key, "guest")
-        assert False, "4th guest question should have raised QuotaExceeded"
+        assert False, "11th guest question should have raised QuotaExceeded"
     except QuotaExceeded as exc:
         assert exc.remaining == 0
-        assert exc.limit == 3
+        assert exc.limit == 10
 
 
-def test_guest_gets_429_on_4th_question():
+def test_guest_gets_429_on_11th_question():
     # Alias test — explicit name mirrors the student equivalent below.
-    key = "guest-alias@gmail.com"
-    for _ in range(3):
+    key = "GUEST-anon-alias"
+    for _ in range(10):
         enforce_quota(key, "guest")
     try:
         enforce_quota(key, "guest")
@@ -56,80 +55,75 @@ def test_guest_gets_429_on_4th_question():
         assert exc.remaining == 0
 
 
-# ── Student quota tests (limit = 5) ──────────────────────────────────────────
+# ── DAU account quota tests (unlimited) ──────────────────────────────────────
 
-def test_dau_student_gets_5_questions_then_429():
+def test_dau_student_has_unlimited_quota():
     key = "student@dau.ac.in"
-    for expected_remaining in (4, 3, 2, 1, 0):
-        assert enforce_quota(key, "student") == expected_remaining
-    try:
-        enforce_quota(key, "student")
-        assert False, "6th student question should have raised QuotaExceeded"
-    except QuotaExceeded as exc:
-        assert exc.remaining == 0
-        assert exc.limit == 5
+    # Well beyond any historical daily limit — never raises, always None.
+    for _ in range(50):
+        assert enforce_quota(key, "student") is None
 
 
-def test_student_429_exception_has_detail():
-    # QuotaExceeded carries both remaining and limit for the 429 response body.
-    key = "detail-check@dau.ac.in"
-    for _ in range(5):
-        enforce_quota(key, "student")
-    try:
-        enforce_quota(key, "student")
-        assert False, "Expected QuotaExceeded"
-    except QuotaExceeded as exc:
-        assert hasattr(exc, "remaining")
-        assert hasattr(exc, "limit")
+def test_dau_faculty_has_unlimited_quota():
+    key = "faculty@dau.ac.in"
+    for _ in range(50):
+        assert enforce_quota(key, "faculty") is None
 
 
-def test_student_limit_greater_than_guest_limit():
-    # Sanity: DAU students (5) always get more questions than guests (3).
-    # NOTE: PR #144's original version of this test imported module-level
-    # ImportError.
+def test_dau_admin_has_unlimited_quota():
+    key = "admin@dau.ac.in"
+    for _ in range(50):
+        assert enforce_quota(key, "admin") is None
+
+
+def test_unlimited_roles_never_touch_the_store():
+    # Unlimited roles should short-circuit before ever reaching the quota
+    # store — a corrupt/unreachable store must not affect DAU accounts.
+    key = "student-store-check@dau.ac.in"
+    enforce_quota(key, "student")
+    assert peek_remaining(key, "student") is None
+
+
+def test_dau_quota_greater_than_guest_quota():
+    # Sanity: unlimited (None) always beats a finite guest quota.
     from pipeline.rate_limiter import QUOTA_LIMITS
-    assert QUOTA_LIMITS["student"] > QUOTA_LIMITS["guest"]
+    assert QUOTA_LIMITS["student"] is None
+    assert isinstance(QUOTA_LIMITS["guest"], int)
 
 
 # ── Per-account isolation ─────────────────────────────────────────────────────
 
 def test_quota_is_keyed_per_account_not_shared():
-    # Two different guest emails must not share one bucket — this guards
-    # against accidentally keying by erp_id='GUEST', which every guest shares.
-    enforce_quota("guest-a@gmail.com", "guest")
-    enforce_quota("guest-a@gmail.com", "guest")
+    # Two different anonymous guest ids must not share one bucket — this
+    # guards against accidentally keying by a fixed erp_id like "GUEST",
+    # which every guest would share.
+    enforce_quota("GUEST-anon-a", "guest")
+    enforce_quota("GUEST-anon-a", "guest")
     # guest-b should still have their full quota
-    assert peek_remaining("guest-b@gmail.com", "guest") == 3
+    assert peek_remaining("GUEST-anon-b", "guest") == 10
 
 
-def test_two_students_have_independent_quotas():
-    # Exhausting one student's quota must not affect another student.
+def test_two_students_have_independent_unlimited_quotas():
+    # Even though DAU quota is unlimited, each account is still keyed
+    # independently (relevant if the policy is ever tightened again).
     key_a = "student-a@dau.ac.in"
     key_b = "student-b@dau.ac.in"
 
-    # Exhaust student A
-    for _ in range(5):
+    for _ in range(20):
         enforce_quota(key_a, "student")
 
-    # A is now rate-limited
-    try:
-        enforce_quota(key_a, "student")
-        assert False, "Expected QuotaExceeded for student A"
-    except QuotaExceeded:
-        pass
-
-    # B still has their full quota
-    assert peek_remaining(key_b, "student") == 5
+    assert enforce_quota(key_a, "student") is None
+    assert peek_remaining(key_b, "student") is None
 
 
 # ── peek_remaining non-destructive check ─────────────────────────────────────
 
 def test_peek_remaining_does_not_consume_quota():
-    key = "peek-test@dau.ac.in"
-    assert peek_remaining(key, "student") == 5
-    assert peek_remaining(key, "student") == 5  # calling peek again doesn't decrement
-    enforce_quota(key, "student")
-    assert peek_remaining(key, "student") == 4
+    key = "peek-test-guest"
+    assert peek_remaining(key, "guest") == 10
+    assert peek_remaining(key, "guest") == 10  # calling peek again doesn't decrement
+    enforce_quota(key, "guest")
+    assert peek_remaining(key, "guest") == 9
 
 
 # ── Wellness guardrail integration ────────────────────────────────────────────


### PR DESCRIPTION
- Google OAuth sign-in now only accepts @dau.ac.in emails (rejects @daiict.ac.in and personal Gmail with a DomainNotAllowed redirect)
- Anonymous guests (no sign-in) can now chat, capped at 10 questions/day, tracked via a cookie-scoped anonymous erp_id
- Verified @dau.ac.in accounts (student/faculty/admin) now have unlimited quota instead of the previous 5/day cap
- Updated composer UI to allow guest chat until quota is exhausted, then prompt sign-in for unlimited access
- Updated backend rate limiter and both test suites accordingly