### PR TITLE
fix(calendar): restore code dropped by #207 conflict resolution

### DIFF
--- a/aura/tests/auth.test.tsx
+++ b/aura/tests/auth.test.tsx
@@ -33,8 +33,8 @@ describe('Domain restriction (only @dau.ac.in may sign in)', () => {
   })
 })
 
-describe('Unauthenticated Composer rendering', () => {
-  it('renders sign-in prompt when unauthenticated', () => {
+describe('Unauthenticated (guest) Composer rendering', () => {
+  it('lets a guest with quota remaining type and send normally', () => {
     vi.mocked(useSession).mockReturnValue({
       data: null,
       status: 'unauthenticated',
@@ -54,8 +54,35 @@ describe('Unauthenticated Composer rendering', () => {
       />
     )
 
-    expect(screen.getByText('Sign in to start chatting with AURA')).toBeInTheDocument()
-    expect(screen.getByText('Sign in')).toBeInTheDocument()
+    // Guests get a normal composer, not a sign-in wall — quota is enforced
+    // separately (see server/rag/pipeline/rate_limiter.py), not by blocking
+    // input outright.
+    expect(screen.getByLabelText('Message AURA')).toBeInTheDocument()
+    expect(screen.getByText('10 messages left')).toBeInTheDocument()
+  })
+
+  it('prompts a guest to sign in once their daily quota is exhausted', () => {
+    vi.mocked(useSession).mockReturnValue({
+      data: null,
+      status: 'unauthenticated',
+      update: vi.fn(),
+    })
+
+    render(
+      <Composer
+        inputText=""
+        setInputText={vi.fn()}
+        loading={false}
+        isRecording={false}
+        isTranscribing={false}
+        onSend={vi.fn()}
+        onMicClick={vi.fn()}
+        remainingQuota={0}
+      />
+    )
+
+    expect(screen.getByText("You've used all your free questions for today.")).toBeInTheDocument()
+    expect(screen.getByText('Sign in with @dau.ac.in for unlimited access')).toBeInTheDocument()
   })
 })
 

--- a/server/api/routes/calendar_routes.py
+++ b/server/api/routes/calendar_routes.py
@@ -93,11 +93,13 @@ def start_calendar_oauth(
     # and the page to return to after consent so the callback can redirect
     # back to wherever the user started rather than always /dashboard.
     state_payload = {
-        "erp_id": identity.erp_id,
-        "typ": GCAL_OAUTH_STATE_TYP,
-        "iss": GCAL_OAUTH_STATE_ISSUER,
-        "aud": GCAL_OAUTH_STATE_AUDIENCE,
-        "exp": datetime.datetime.utcnow() + datetime.timedelta(minutes=10),
+        "erp_id":    identity.erp_id,
+        "role":      identity.role,
+        "return_to": return_to,
+        "typ":       GCAL_OAUTH_STATE_TYP,
+        "iss":       GCAL_OAUTH_STATE_ISSUER,
+        "aud":       GCAL_OAUTH_STATE_AUDIENCE,
+        "exp":       datetime.datetime.utcnow() + datetime.timedelta(minutes=10),
     }
     state_token = jwt.encode(state_payload, secret, algorithm=ALGORITHM)
 

--- a/server/rag/pipeline/google_calendar/token_vault.py
+++ b/server/rag/pipeline/google_calendar/token_vault.py
@@ -63,10 +63,12 @@ def _fernet() -> Fernet:
 
 
 def _connect():
+    db_path = Path(os.environ.get("GOOGLE_CALENDAR_VAULT_DB",
+                                   "/var/lib/aura/gcal_tokens.db"))
     # mode=0o700 restricts a vault dir AURA creates itself; it does not loosen
     # (or tighten) an already-existing shared parent such as /tmp.
-    DB_PATH.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-    conn = sqlite3.connect(DB_PATH)
+    db_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    conn = sqlite3.connect(db_path)
     conn.execute("""
         CREATE TABLE IF NOT EXISTS gcal_tokens (
             erp_id          TEXT PRIMARY KEY,
@@ -75,10 +77,23 @@ def _connect():
             linked_at       TEXT NOT NULL
         )
     """)
+    # Tracks every event AURA has created on a student's calendar, keyed by
+    # the stable "slot key" (master row id, or override id for custom
+    # entries) so a re-sync updates the same event in place instead of
+    # duplicating it, and disconnect/unsync can clean everything up.
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS gcal_synced_events (
+            erp_id          TEXT NOT NULL,
+            slot_key        TEXT NOT NULL,
+            google_event_id TEXT NOT NULL,
+            updated_at      TEXT NOT NULL,
+            PRIMARY KEY (erp_id, slot_key)
+        )
+    """)
     # Restrict token DB permissions before any token blob is written, matching
     # ecampus/credentials_vault.py — OAuth tokens are just as sensitive.
     try:
-        os.chmod(DB_PATH, 0o600)
+        os.chmod(db_path, 0o600)
     except OSError:
         pass
     return conn


### PR DESCRIPTION
## Summary

CI has been red on `main` since #207 merged (run [30213973205](https://github.com/ossdaiict/DAU-pwa/actions/runs/30213973205)), and CD deployed the result.

#207 resolved three merge conflicts by taking the feature branch's side. Each of those conflicts paired our security hardening against new feature code from #206, so keeping only our side left callers without their callees. This restores the dropped code while preserving the hardening.

### `server/rag/pipeline/google_calendar/token_vault.py`

The most serious one — the calendar vault is currently dead on `main`, not just failing tests.

- `_connect()` referenced `DB_PATH`, which is **defined nowhere in the module** (flake8 `F821: undefined name`). Every vault call raised `NameError`. Restored the lazy `GOOGLE_CALENDAR_VAULT_DB` lookup — which is what the comment at L45-48 already documents as the intended design — and reapplied our `0o700` mkdir / `0o600` chmod to it.
- The `gcal_synced_events` `CREATE TABLE` was dropped while four functions still query that table (L140, L158, L167, L179), so student calendar sync raised `no such table`.

### `server/api/routes/calendar_routes.py`

`state_payload` lost `"role"` and `"return_to"` while the OAuth callback still reads both (L186, L194). Effect: every student was treated as `role="faculty"` after consent, and the post-consent redirect was pinned to `/dashboard` regardless of where the flow started. Our `typ`/`iss`/`aud` CSRF binding is unchanged.

### `aura/tests/auth.test.tsx`

Restored the #206 tests — this is the failure CI caught. `Composer` no longer renders `"Sign in to start chatting with AURA"`; guests get a quota-metered composer instead, so the old assertion could never pass.

## Test plan

| Check | Result |
|---|---|
| `pnpm test` | 5/5 passed |
| `pytest -k "calendar or vault or token"` | 20/20 passed |
| `pnpm type-check` | clean |
| `pnpm lint` | 0 errors (14 pre-existing warnings, unrelated files) |
| `python3 -m py_compile` | OK |

Also ran a runtime check against a scratch DB confirming `_connect()` now creates both `gcal_tokens` and `gcal_synced_events`, and that `record_synced_event` / `get_synced_event_map` / `unlink_calendar` round-trip. The same call on `main` raises `NameError` before reaching any of that.

No UI changes, so no screenshots.

## Notes for reviewers

- Pre-existing flake8 style noise (E501/E221/F401) in both Python files was left alone as out of scope.
- The deployed backend currently has a non-functional calendar vault — worth a redeploy once this lands.
- Worth checking why #207 merged with a red CI; if required status checks aren't enforced on `main`, this will recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)