### PR TITLE
feat(memory): add persistent user memory

### DIFF
--- a/aura/app/api/auth/history/route.ts
+++ b/aura/app/api/auth/history/route.ts
@@ -29,6 +29,10 @@ const historyMessageSchema = z.object({
 const historyThreadSchema = z.object({
   id: z.string().min(1).max(128),
   title: z.string().max(500),
+  updatedAt: z.number().optional(),
+  summary: z.string().max(20_000).optional(),
+  summaryTurnCount: z.number().int().nonnegative().optional(),
+  continuedFromId: z.string().min(1).max(128).optional(),
   messages: z.array(historyMessageSchema).max(MAX_MESSAGES_PER_THREAD),
 })
 

--- a/aura/hooks/use-aura-chat.ts
+++ b/aura/hooks/use-aura-chat.ts
@@ -289,10 +289,11 @@ export function useAuraChat() {
 
   const persistMessages = useCallback(
     (threadId: string, next: ChatMessage[], title?: string) => {
+      const updatedAt = next[next.length - 1]?.timestamp ?? Date.now()
       setThreads((prev) =>
         prev.map((t) =>
           t.id === threadId
-            ? { ...t, messages: next, title: title ?? t.title }
+            ? { ...t, messages: next, title: title ?? t.title, updatedAt }
             : t,
         ),
       )
@@ -394,6 +395,7 @@ export function useAuraChat() {
           id: threadId,
           title: deriveTitle(trimmed),
           messages: [userMsg],
+          updatedAt: userMsg.timestamp,
         }
         setThreads((prev) => [newThread, ...prev])
         setActiveThreadIdState(threadId)
@@ -526,6 +528,7 @@ export function useAuraChat() {
             id: contId,
             title: `${activeThread?.title ?? deriveTitle(trimmed)} (cont.)`,
             messages: [],
+            updatedAt: Date.now(),
             summary: carriedSummary,
             summaryTurnCount: 0,
             continuedFromId: threadId,

--- a/server/api/routes/chat_routes.py
+++ b/server/api/routes/chat_routes.py
@@ -70,9 +70,17 @@ def _resolve_request(body: ChatRequest, identity: Identity, req: Request):
 
 
 def _summary_for_generation(user_memory: str, thread_summary: str) -> str:
+    from pipeline.memory.conversation_memory import get_conversation_memory, _approx_tokens, _truncate_tokens
+    
+    max_tokens = get_conversation_memory().summary_max_tokens
+    thread_len = _approx_tokens(thread_summary)
+    rem_tokens = max(0, max_tokens - thread_len)
+    
     parts = []
     if user_memory:
-        parts.append("Persistent User Memory\n" + user_memory)
+        user_memory = _truncate_tokens(user_memory, rem_tokens)
+        if user_memory:
+            parts.append("Persistent User Memory\n" + user_memory)
     if thread_summary:
         parts.append("Current Thread Summary\n" + thread_summary)
     return "\n\n".join(parts)

--- a/server/api/routes/chat_routes.py
+++ b/server/api/routes/chat_routes.py
@@ -13,6 +13,7 @@ from api.request_context import AcademicScopeResolver, RequestContext
 from api.deps import chat_queue_lock, get_aura
 from api.schemas import ChatRequest
 from pipeline.memory.conversation_memory import get_conversation_memory
+from pipeline.memory.user_memory import get_user_memory_store
 from pipeline.rate_limiter import QuotaExceeded, enforce_quota
 from access_control import resolve_effective_role
 
@@ -64,6 +65,15 @@ def _resolve_request(body: ChatRequest, identity: Identity, req: Request):
     return history, display_profile, request_context
 
 
+def _summary_for_generation(user_memory: str, thread_summary: str) -> str:
+    parts = []
+    if user_memory:
+        parts.append("Persistent User Memory\n" + user_memory)
+    if thread_summary:
+        parts.append("Current Thread Summary\n" + thread_summary)
+    return "\n\n".join(parts)
+
+
 @router.post("/chat")
 async def chat(
     req: Request,
@@ -83,14 +93,19 @@ def _ask_with_memory(request, identity, history, display_profile, request_contex
     # the updated summary + memory metadata so the (stateless) client can persist
     # the digest and advance its per-thread pointer.
     mem_result = get_conversation_memory().prepare(request.summary, history)
+    user_memory_store = get_user_memory_store()
+    identity_dict = identity.as_dict()
+    user_memory = user_memory_store.get(identity_dict)
     result = get_aura().ask(
         question=request.question,
         history=mem_result.history,
-        identity=identity.as_dict(),
+        identity=identity_dict,
         display_profile=display_profile,
-        summary=mem_result.summary,
+        summary=_summary_for_generation(user_memory, mem_result.summary),
         request_context=request_context,
     )
+    if mem_result.summary_changed:
+        user_memory_store.merge(identity_dict, mem_result.summary)
     result = dict(result) if isinstance(result, dict) else {"answer": str(result)}
     result["memory"] = {
         "summary": mem_result.summary,
@@ -126,17 +141,22 @@ async def chat_stream(
 
     def _run() -> None:
         try:
-            mem_result = get_conversation_memory().prepare(request.summary, history)
+            mem_result = get_conversation_memory().prepare(body.summary, history)
             loop.call_soon_threadsafe(events.put_nowait, ("summary", mem_result))
+            user_memory_store = get_user_memory_store()
+            identity_dict = identity.as_dict()
+            user_memory = user_memory_store.get(identity_dict)
             result = get_aura().ask(
                 question=body.question,
                 history=mem_result.history,
-                identity=identity.as_dict(),
+                identity=identity_dict,
                 display_profile=display_profile,
                 on_delta=on_delta,
-                summary=mem_result.summary,
+                summary=_summary_for_generation(user_memory, mem_result.summary),
                 request_context=request_context,
             )
+            if mem_result.summary_changed:
+                user_memory_store.merge(identity_dict, mem_result.summary)
         except Exception as exc:  # e.g. AURA init failure — never kill the stream silently
             loop.call_soon_threadsafe(events.put_nowait, ("error", str(exc)))
         else:

--- a/server/api/routes/chat_routes.py
+++ b/server/api/routes/chat_routes.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import logging
+import os
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.concurrency import run_in_threadpool
@@ -20,6 +21,13 @@ from access_control import resolve_effective_role
 router = APIRouter(tags=["chat"])
 _scope_resolver = AcademicScopeResolver()
 logger = logging.getLogger(__name__)
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int((os.getenv(name) or "").strip() or default)
+    except (TypeError, ValueError):
+        return default
 
 
 def _resolve_request(body: ChatRequest, identity: Identity, req: Request):
@@ -70,15 +78,15 @@ def _resolve_request(body: ChatRequest, identity: Identity, req: Request):
 
 
 def _summary_for_generation(user_memory: str, thread_summary: str) -> str:
-    from pipeline.memory.conversation_memory import get_conversation_memory, _approx_tokens, _truncate_tokens
-    
-    max_tokens = get_conversation_memory().summary_max_tokens
-    thread_len = _approx_tokens(thread_summary)
-    rem_tokens = max(0, max_tokens - thread_len)
-    
+    from pipeline.memory.conversation_memory import _truncate_tokens
+
+    conversation_memory = get_conversation_memory()
+    thread_summary = _truncate_tokens(thread_summary or "", conversation_memory.summary_max_tokens)
+    user_memory_tokens = _env_int("AURA_USER_MEMORY_TOKENS", 400)
+
     parts = []
     if user_memory:
-        user_memory = _truncate_tokens(user_memory, rem_tokens)
+        user_memory = _truncate_tokens(user_memory, user_memory_tokens)
         if user_memory:
             parts.append("Persistent User Memory\n" + user_memory)
     if thread_summary:
@@ -107,29 +115,6 @@ def _ask_with_memory(request, identity, history, display_profile, request_contex
     # Compact older turns into the running summary before generating, then return
     # the updated summary + memory metadata so the (stateless) client can persist
     # the digest and advance its per-thread pointer.
-    mem_result = get_conversation_memory().prepare(body.summary, history)
-    result = get_aura().ask(
-        question=request.question,
-        history=mem_result.history,
-        identity=identity.as_dict(),
-        display_profile=display_profile,
-        summary=mem_result.summary,
-        request_context=request_context,
-    )
-    result = dict(result) if isinstance(result, dict) else {"answer": str(result)}
-    result["memory"] = {
-        "summary": mem_result.summary,
-        "foldedTurns": mem_result.folded_turns,
-        "summaryChanged": mem_result.summary_changed,
-        "shouldFork": mem_result.should_fork,
-    }
-    return result
-
-
-def _ask_with_memory(request, identity, history, display_profile, request_context) -> dict:
-    # Compact older turns into the running summary before generating, then return
-    # the updated summary + memory metadata so the (stateless) client can persist
-    # the digest and advance its per-thread pointer.
     mem_result = get_conversation_memory().prepare(request.summary, history)
     user_memory_store = get_user_memory_store()
     identity_dict = identity.as_dict()
@@ -143,7 +128,7 @@ def _ask_with_memory(request, identity, history, display_profile, request_contex
         request_context=request_context,
     )
     if mem_result.summary_changed:
-        user_memory_store.merge(identity_dict, mem_result.summary)
+        user_memory_store.merge(identity_dict, mem_result.summary, request.summary or "")
     result = dict(result) if isinstance(result, dict) else {"answer": str(result)}
     result["memory"] = {
         "summary": mem_result.summary,
@@ -194,7 +179,7 @@ async def chat_stream(
                 request_context=request_context,
             )
             if mem_result.summary_changed:
-                user_memory_store.merge(identity_dict, mem_result.summary)
+                user_memory_store.merge(identity_dict, mem_result.summary, body.summary or "")
         except Exception as exc:  # e.g. AURA init failure — never kill the stream silently
             loop.call_soon_threadsafe(events.put_nowait, ("error", str(exc)))
         else:

--- a/server/rag/.env.example
+++ b/server/rag/.env.example
@@ -10,6 +10,8 @@ PROD_FRONTEND_ORIGIN=https://aura.dau.ac.in
 
 # Shared question quota across API workers (omit for single-process in-memory)
 # REDIS_URL=redis://localhost:6379/0
+# Optional key prefix for per-user persistent memory stored in Redis.
+# REDIS_USER_MEMORY_PREFIX=aura:user-memory:
 
 # Optional: restrict /internal/* to Next.js BFF IPs/CIDRs (comma-separated)
 # INTERNAL_RESOLVE_ALLOWLIST=10.0.0.0/8,127.0.0.1

--- a/server/rag/pipeline/memory/user_memory.py
+++ b/server/rag/pipeline/memory/user_memory.py
@@ -1,0 +1,124 @@
+"""Per-user persistent memory for cross-thread personalisation.
+
+Thread memory remains client-owned (`summary` + tail). This store is the
+backend-owned layer: when a thread gets compacted, its summary is merged into a
+per-user memory blob so future threads can inherit useful preferences/facts.
+
+Redis is used when REDIS_URL is configured; local/dev falls back to process
+memory so tests and single-process runs keep working.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import threading
+from typing import Optional, Protocol
+
+MAX_USER_MEMORY_CHARS = 20_000
+
+
+class UserMemoryStore(Protocol):
+    def get(self, identity: dict) -> str: ...
+    def merge(self, identity: dict, thread_summary: str) -> str: ...
+
+
+def _identity_key(identity: dict) -> Optional[str]:
+    role = identity.get("role")
+    if role == "guest":
+        return None
+    subject = identity.get("email") or identity.get("erp_id")
+    if not subject:
+        return None
+    digest = hashlib.sha256(f"{role}:{str(subject).lower()}".encode()).hexdigest()
+    return digest
+
+
+def _normalise(summary: str) -> str:
+    return (summary or "").strip()
+
+
+def _merge_memory(existing: str, thread_summary: str) -> str:
+    existing = _normalise(existing)
+    thread_summary = _normalise(thread_summary)
+    if not thread_summary:
+        return existing
+    if thread_summary in existing:
+        return existing
+
+    block = f"## Prior Thread Memory\n{thread_summary}"
+    merged = f"{existing}\n\n{block}".strip() if existing else block
+    if len(merged) <= MAX_USER_MEMORY_CHARS:
+        return merged
+    return merged[-MAX_USER_MEMORY_CHARS:].lstrip()
+
+
+class InMemoryUserMemoryStore:
+    def __init__(self):
+        self._data: dict[str, str] = {}
+        self._lock = threading.Lock()
+
+    def get(self, identity: dict) -> str:
+        key = _identity_key(identity)
+        if key is None:
+            return ""
+        with self._lock:
+            return self._data.get(key, "")
+
+    def merge(self, identity: dict, thread_summary: str) -> str:
+        key = _identity_key(identity)
+        if key is None:
+            return ""
+        with self._lock:
+            merged = _merge_memory(self._data.get(key, ""), thread_summary)
+            self._data[key] = merged
+            return merged
+
+
+class RedisUserMemoryStore:
+    def __init__(self, redis_url: str):
+        import redis
+
+        self._r = redis.Redis.from_url(redis_url, decode_responses=True)
+        self._prefix = os.environ.get("REDIS_USER_MEMORY_PREFIX", "aura:user-memory:")
+
+    def _redis_key(self, identity: dict) -> Optional[str]:
+        key = _identity_key(identity)
+        return f"{self._prefix}{key}" if key else None
+
+    def get(self, identity: dict) -> str:
+        key = self._redis_key(identity)
+        if key is None:
+            return ""
+        return self._r.get(key) or ""
+
+    def merge(self, identity: dict, thread_summary: str) -> str:
+        key = self._redis_key(identity)
+        if key is None:
+            return ""
+        existing = self._r.get(key) or ""
+        merged = _merge_memory(existing, thread_summary)
+        self._r.set(key, merged)
+        return merged
+
+
+def _build_store() -> UserMemoryStore:
+    redis_url = os.environ.get("REDIS_URL", "").strip()
+    if redis_url:
+        return RedisUserMemoryStore(redis_url)
+    return InMemoryUserMemoryStore()
+
+
+_shared: Optional[UserMemoryStore] = None
+
+
+def get_user_memory_store() -> UserMemoryStore:
+    global _shared
+    if _shared is None:
+        _shared = _build_store()
+    return _shared
+
+
+def reset_user_memory_store_for_tests(store: Optional[UserMemoryStore] = None) -> None:
+    global _shared
+    _shared = store if store is not None else InMemoryUserMemoryStore()

--- a/server/rag/pipeline/memory/user_memory.py
+++ b/server/rag/pipeline/memory/user_memory.py
@@ -96,10 +96,26 @@ class RedisUserMemoryStore:
         key = self._redis_key(identity)
         if key is None:
             return ""
-        existing = self._r.get(key) or ""
-        merged = _merge_memory(existing, thread_summary)
-        self._r.set(key, merged)
-        return merged
+        
+        import redis
+        try:
+            with self._r.pipeline() as pipe:
+                while True:
+                    try:
+                        pipe.watch(key)
+                        existing = pipe.get(key) or ""
+                        merged = _merge_memory(existing, thread_summary)
+                        pipe.multi()
+                        pipe.set(key, merged)
+                        pipe.execute()
+                        return merged
+                    except redis.WatchError:
+                        continue
+        except redis.RedisError:
+            existing = self._r.get(key) or ""
+            merged = _merge_memory(existing, thread_summary)
+            self._r.set(key, merged)
+            return merged
 
 
 def _build_store() -> UserMemoryStore:

--- a/server/rag/pipeline/memory/user_memory.py
+++ b/server/rag/pipeline/memory/user_memory.py
@@ -11,18 +11,26 @@ memory so tests and single-process runs keep working.
 from __future__ import annotations
 
 import hashlib
+import logging
 import os
 import threading
 from typing import Optional, Protocol
 
 MAX_USER_MEMORY_CHARS = 20_000
+DEFAULT_USER_MEMORY_TTL_SECONDS = 90 * 24 * 60 * 60
+logger = logging.getLogger(__name__)
 
 
 class UserMemoryStore(Protocol):
     def get(self, identity: dict) -> str:
         pass
 
-    def merge(self, identity: dict, thread_summary: str) -> str:
+    def merge(
+        self,
+        identity: dict,
+        thread_summary: str,
+        previous_thread_summary: str = "",
+    ) -> str:
         pass
 
 
@@ -30,7 +38,7 @@ def _identity_key(identity: dict) -> Optional[str]:
     role = identity.get("role")
     if role == "guest":
         return None
-    subject = identity.get("email") or identity.get("erp_id")
+    subject = identity.get("erp_id")
     if not subject:
         return None
     digest = hashlib.sha256(f"{role}:{str(subject).lower()}".encode()).hexdigest()
@@ -41,16 +49,49 @@ def _normalise(summary: str) -> str:
     return (summary or "").strip()
 
 
-def _merge_memory(existing: str, thread_summary: str) -> str:
+def _memory_blocks(existing: str) -> list[str]:
+    existing = _normalise(existing)
+    if not existing:
+        return []
+    blocks = []
+    for raw in existing.split("## Prior Thread Memory"):
+        block = _normalise(raw)
+        if block:
+            blocks.append(block)
+    return blocks
+
+
+def _merge_memory(existing: str, thread_summary: str, previous_thread_summary: str = "") -> str:
     existing = _normalise(existing)
     thread_summary = _normalise(thread_summary)
+    previous_thread_summary = _normalise(previous_thread_summary)
     if not thread_summary:
         return existing
-    if thread_summary in existing:
-        return existing
 
-    block = f"## Prior Thread Memory\n{thread_summary}"
-    merged = f"{existing}\n\n{block}".strip() if existing else block
+    blocks = _memory_blocks(existing)
+    replaced = False
+    next_blocks = []
+    for block in blocks:
+        if block == thread_summary:
+            replaced = True
+            next_blocks.append(thread_summary)
+        elif previous_thread_summary and block == previous_thread_summary:
+            replaced = True
+            next_blocks.append(thread_summary)
+        else:
+            next_blocks.append(block)
+    if not replaced:
+        next_blocks.append(thread_summary)
+
+    deduped = []
+    seen = set()
+    for block in next_blocks:
+        if block in seen:
+            continue
+        seen.add(block)
+        deduped.append(block)
+
+    merged = "\n\n".join(f"## Prior Thread Memory\n{block}" for block in deduped)
     if len(merged) <= MAX_USER_MEMORY_CHARS:
         return merged
     return merged[-MAX_USER_MEMORY_CHARS:].lstrip()
@@ -68,12 +109,21 @@ class InMemoryUserMemoryStore:
         with self._lock:
             return self._data.get(key, "")
 
-    def merge(self, identity: dict, thread_summary: str) -> str:
+    def merge(
+        self,
+        identity: dict,
+        thread_summary: str,
+        previous_thread_summary: str = "",
+    ) -> str:
         key = _identity_key(identity)
         if key is None:
             return ""
         with self._lock:
-            merged = _merge_memory(self._data.get(key, ""), thread_summary)
+            merged = _merge_memory(
+                self._data.get(key, ""),
+                thread_summary,
+                previous_thread_summary,
+            )
             self._data[key] = merged
             return merged
 
@@ -84,6 +134,10 @@ class RedisUserMemoryStore:
 
         self._r = redis.Redis.from_url(redis_url, decode_responses=True)
         self._prefix = os.environ.get("REDIS_USER_MEMORY_PREFIX", "aura:user-memory:")
+        self._ttl_seconds = _env_int(
+            "REDIS_USER_MEMORY_TTL_SECONDS",
+            DEFAULT_USER_MEMORY_TTL_SECONDS,
+        )
 
     def _redis_key(self, identity: dict) -> Optional[str]:
         key = _identity_key(identity)
@@ -93,13 +147,24 @@ class RedisUserMemoryStore:
         key = self._redis_key(identity)
         if key is None:
             return ""
-        return self._r.get(key) or ""
+        import redis
 
-    def merge(self, identity: dict, thread_summary: str) -> str:
+        try:
+            return self._r.get(key) or ""
+        except redis.RedisError as exc:
+            logger.warning("Redis user-memory get failed for %s: %s", key, exc)
+            return ""
+
+    def merge(
+        self,
+        identity: dict,
+        thread_summary: str,
+        previous_thread_summary: str = "",
+    ) -> str:
         key = self._redis_key(identity)
         if key is None:
             return ""
-        
+
         import redis
         try:
             with self._r.pipeline() as pipe:
@@ -107,18 +172,30 @@ class RedisUserMemoryStore:
                     try:
                         pipe.watch(key)
                         existing = pipe.get(key) or ""
-                        merged = _merge_memory(existing, thread_summary)
+                        merged = _merge_memory(
+                            existing,
+                            thread_summary,
+                            previous_thread_summary,
+                        )
                         pipe.multi()
-                        pipe.set(key, merged)
+                        if self._ttl_seconds > 0:
+                            pipe.set(key, merged, ex=self._ttl_seconds)
+                        else:
+                            pipe.set(key, merged)
                         pipe.execute()
                         return merged
                     except redis.WatchError:
                         continue
         except redis.RedisError:
-            existing = self._r.get(key) or ""
-            merged = _merge_memory(existing, thread_summary)
-            self._r.set(key, merged)
-            return merged
+            logger.warning("Redis user-memory merge failed for %s", key, exc_info=True)
+            return ""
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int((os.getenv(name) or "").strip() or default)
+    except (TypeError, ValueError):
+        return default
 
 
 def _build_store() -> UserMemoryStore:

--- a/server/rag/pipeline/memory/user_memory.py
+++ b/server/rag/pipeline/memory/user_memory.py
@@ -19,8 +19,11 @@ MAX_USER_MEMORY_CHARS = 20_000
 
 
 class UserMemoryStore(Protocol):
-    def get(self, identity: dict) -> str: ...
-    def merge(self, identity: dict, thread_summary: str) -> str: ...
+    def get(self, identity: dict) -> str:
+        pass
+
+    def merge(self, identity: dict, thread_summary: str) -> str:
+        pass
 
 
 def _identity_key(identity: dict) -> Optional[str]:

--- a/server/rag/pipeline/rate_limiter.py
+++ b/server/rag/pipeline/rate_limiter.py
@@ -15,6 +15,7 @@ in-memory store for single-process dev/tests.
 import os
 import time
 import threading
+import uuid
 from dataclasses import dataclass, field
 from typing import Optional, Protocol
 
@@ -92,19 +93,31 @@ class RedisQuotaStore:
         now = time.time()
         cutoff = now - QUOTA_WINDOW_SECONDS
         rkey = self._key(key)
-        pipe = self._r.pipeline()
-        pipe.zremrangebyscore(rkey, 0, cutoff)
-        pipe.zcard(rkey)
-        _, count = pipe.execute()
-        if count >= limit:
+        ttl = QUOTA_WINDOW_SECONDS + 60
+        member = f"{now}:{os.getpid()}:{uuid.uuid4().hex}"
+        allowed, count = self._r.eval(
+            """
+            redis.call('ZREMRANGEBYSCORE', KEYS[1], 0, ARGV[1])
+            local count = redis.call('ZCARD', KEYS[1])
+            local limit = tonumber(ARGV[2])
+            if count >= limit then
+              return {0, count}
+            end
+            redis.call('ZADD', KEYS[1], ARGV[4], ARGV[3])
+            redis.call('EXPIRE', KEYS[1], ARGV[5])
+            return {1, redis.call('ZCARD', KEYS[1])}
+            """,
+            1,
+            rkey,
+            cutoff,
+            limit,
+            member,
+            now,
+            ttl,
+        )
+        if int(allowed) == 0:
             raise QuotaExceeded(limit=limit, remaining=0)
-        member = f"{now}:{os.getpid()}:{id(object())}"
-        pipe = self._r.pipeline()
-        pipe.zadd(rkey, {member: now})
-        pipe.expire(rkey, QUOTA_WINDOW_SECONDS + 60)
-        pipe.zcard(rkey)
-        _, _, new_count = pipe.execute()
-        return max(0, limit - int(new_count))
+        return max(0, limit - int(count))
 
     def remaining(self, key: str, limit: int) -> int:
         now = time.time()

--- a/server/rag/pipeline/retrieval/reranker.py
+++ b/server/rag/pipeline/retrieval/reranker.py
@@ -100,6 +100,7 @@ class Reranker:
 
         if cross_scores is None:
             self._ensure_local_model()
+            import torch
             inputs = self.tokenizer(
                 pairs,
                 padding=True,

--- a/server/rag/pipeline/retrieval/reranker.py
+++ b/server/rag/pipeline/retrieval/reranker.py
@@ -1,15 +1,27 @@
 import os
 import math
-import torch
-from transformers import (
-    AutoTokenizer,
-    AutoModelForSequenceClassification
-)
 
 
 class Reranker:
 
     def __init__(self):
+        self.device = None
+        self.tokenizer = None
+        self.model = None
+        self.H1_BOOST = 0.10
+        self.H2_BOOST = 0.20
+        self.H3_BOOST = 0.15
+
+    def _ensure_local_model(self):
+        if self.model is not None and self.tokenizer is not None:
+            return
+
+        import torch
+        from transformers import (
+            AutoTokenizer,
+            AutoModelForSequenceClassification
+        )
+
         env_device = os.getenv("RERANKER_DEVICE")
         if env_device:
             self.device = torch.device(env_device)
@@ -34,10 +46,6 @@ class Reranker:
         ).to(self.device)
 
         self.model.eval()
-
-        self.H1_BOOST = 0.10
-        self.H2_BOOST = 0.20
-        self.H3_BOOST = 0.15
 
     def rerank(
         self,
@@ -91,6 +99,7 @@ class Reranker:
                 logging.getLogger(__name__).warning("Remote reranker service failed: %s. Falling back to local model.", e)
 
         if cross_scores is None:
+            self._ensure_local_model()
             inputs = self.tokenizer(
                 pairs,
                 padding=True,

--- a/server/rag/pipeline/retrieval/retrieval_pipeline.py
+++ b/server/rag/pipeline/retrieval/retrieval_pipeline.py
@@ -1120,17 +1120,15 @@ class RetrievalPipeline:
             logger.info("Semantic retrieval disabled because the vector index is unavailable; continuing with entity-path results only.")
         else:
             try:
-                query_embedding = self.retriever.model.encode(
-                    ["Represent this sentence for searching relevant passages: " + query],
-                    normalize_embeddings=True,
-                    convert_to_numpy=True
-                )
+                query_embedding = self.retriever.embed_query(query)
+                if query_embedding is None:
+                    raise RuntimeError("Query embedding unavailable")
                 semantic_filter = self._combine_filters(
                     {"authorization": {"$in": allowed_roles}} if allowed_roles else None,
                     self._academic_scope_filter(academic_scope),
                 )
                 results = self.retriever.index.query(
-                    vector=query_embedding[0].tolist(),
+                    vector=query_embedding,
                     top_k=50,
                     include_metadata=True,
                     filter=semantic_filter

--- a/server/rag/pipeline/retrieval/retriever.py
+++ b/server/rag/pipeline/retrieval/retriever.py
@@ -80,12 +80,16 @@ class Retriever:
             except Exception as e:
                 logger.warning("Remote embedding service failed: %s. Falling back to local model.", e)
 
-        query_embedding = self._local_model().encode(
-            [query_text],
-            normalize_embeddings=True,
-            convert_to_numpy=True
-        )
-        return query_embedding[0].tolist()
+        try:
+            query_embedding = self._local_model().encode(
+                [query_text],
+                normalize_embeddings=True,
+                convert_to_numpy=True
+            )
+            return query_embedding[0].tolist()
+        except Exception as e:
+            logger.warning("Local embedding model failed: %s", e)
+            return None
 
     def retrieve(
         self,
@@ -100,7 +104,7 @@ class Retriever:
         # filter: doing so would allow a maintenance flag to bypass scope.
         pinecone_filter = metadata_filter
 
-        query_embedding_list = self.embed_query(query)
+        query_embedding_list = self.embed_query(query) if self.index else None
 
         dense_results = []
         if self.index and query_embedding_list is not None:

--- a/server/rag/pipeline/retrieval/retriever.py
+++ b/server/rag/pipeline/retrieval/retriever.py
@@ -1,8 +1,8 @@
 import os
 import logging
 from pathlib import Path
+from typing import Optional
 from dotenv import load_dotenv
-from sentence_transformers import SentenceTransformer
 
 # Query-time embeddings MUST use the same model as ingestion-time
 # embeddings or retrieval silently degrades — single source of truth.
@@ -22,9 +22,7 @@ class Retriever:
 
         load_dotenv()
 
-        self.model = SentenceTransformer(
-            MODEL_NAME
-        )
+        self.model = None
 
         metadata_path = (
             Path(__file__).resolve().parent.parent
@@ -54,25 +52,18 @@ class Retriever:
         # needed to change.
         self.index = build_index_adapter()
 
-    def retrieve(
-        self,
-        query,
-        top_k=TOP_K,
-        metadata_filter=None,
-        allowed_roles=None
-    ):
+    def _local_model(self):
+        if self.model is None:
+            from sentence_transformers import SentenceTransformer
+            self.model = SentenceTransformer(MODEL_NAME)
+        return self.model
 
-        # Metadata filters include authorization and, for authenticated
-        # students, hard academic applicability. Never disable the complete
-        # filter: doing so would allow a maintenance flag to bypass scope.
-        pinecone_filter = metadata_filter
-        
+    def embed_query(self, query: str) -> Optional[list[float]]:
         query_text = (
             "Represent this sentence for searching relevant passages: "
             + query
         )
         embedding_service_url = os.getenv("EMBEDDING_SERVICE_URL")
-        query_embedding_list = None
 
         if embedding_service_url:
             try:
@@ -85,20 +76,34 @@ class Retriever:
                 if resp.status_code == 200:
                     data = resp.json()
                     if "embeddings" in data and len(data["embeddings"]) > 0:
-                        query_embedding_list = data["embeddings"][0]
+                        return data["embeddings"][0]
             except Exception as e:
                 logger.warning("Remote embedding service failed: %s. Falling back to local model.", e)
 
-        if query_embedding_list is None:
-            query_embedding = self.model.encode(
-                [query_text],
-                normalize_embeddings=True,
-                convert_to_numpy=True
-            )
-            query_embedding_list = query_embedding[0].tolist()
+        query_embedding = self._local_model().encode(
+            [query_text],
+            normalize_embeddings=True,
+            convert_to_numpy=True
+        )
+        return query_embedding[0].tolist()
+
+    def retrieve(
+        self,
+        query,
+        top_k=TOP_K,
+        metadata_filter=None,
+        allowed_roles=None
+    ):
+
+        # Metadata filters include authorization and, for authenticated
+        # students, hard academic applicability. Never disable the complete
+        # filter: doing so would allow a maintenance flag to bypass scope.
+        pinecone_filter = metadata_filter
+
+        query_embedding_list = self.embed_query(query)
 
         dense_results = []
-        if self.index:
+        if self.index and query_embedding_list is not None:
             try:
                 results = self.index.query(
                     vector=query_embedding_list,

--- a/server/rag/pipeline/tests/test_chat_memory_budget.py
+++ b/server/rag/pipeline/tests/test_chat_memory_budget.py
@@ -13,7 +13,7 @@ class _FakeConversationMemory:
 
 def test_persistent_memory_has_dedicated_generation_budget(monkeypatch):
     monkeypatch.setenv("AURA_USER_MEMORY_TOKENS", "1")
-    monkeypatch.setattr(chat_routes, "get_conversation_memory", lambda: _FakeConversationMemory())
+    monkeypatch.setattr(chat_routes, "get_conversation_memory", _FakeConversationMemory)
 
     summary = chat_routes._summary_for_generation(
         "User prefers short direct answers and timetable examples.",

--- a/server/rag/pipeline/tests/test_chat_memory_budget.py
+++ b/server/rag/pipeline/tests/test_chat_memory_budget.py
@@ -1,0 +1,25 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from api.routes import chat_routes
+
+
+class _FakeConversationMemory:
+    summary_max_tokens = 1
+
+
+def test_persistent_memory_has_dedicated_generation_budget(monkeypatch):
+    monkeypatch.setenv("AURA_USER_MEMORY_TOKENS", "1")
+    monkeypatch.setattr(chat_routes, "get_conversation_memory", lambda: _FakeConversationMemory())
+
+    summary = chat_routes._summary_for_generation(
+        "User prefers short direct answers and timetable examples.",
+        "Current thread summary that already fills the thread budget.",
+    )
+
+    assert "Persistent User Memory" in summary
+    assert "User" in summary
+    assert "Current Thread Summary" in summary

--- a/server/rag/pipeline/tests/test_redis_quota.py
+++ b/server/rag/pipeline/tests/test_redis_quota.py
@@ -58,6 +58,18 @@ def _make_store_with_fake_zset():
     client = MagicMock()
     client.pipeline.side_effect = lambda: FakePipe()
 
+    def eval_script(_script, _numkeys, key, cutoff, limit, member, now, _ttl):
+        bucket = zsets.setdefault(key, {})
+        for existing_member, score in list(bucket.items()):
+            if score <= cutoff:
+                del bucket[existing_member]
+        if len(bucket) >= limit:
+            return [0, len(bucket)]
+        bucket[member] = now
+        return [1, len(bucket)]
+
+    client.eval.side_effect = eval_script
+
     with patch("redis.Redis.from_url", return_value=client):
         store = RedisQuotaStore("redis://localhost:6379/0")
     return store

--- a/server/rag/pipeline/tests/test_user_memory.py
+++ b/server/rag/pipeline/tests/test_user_memory.py
@@ -1,3 +1,8 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
 from pipeline.memory.user_memory import (
     InMemoryUserMemoryStore,
     _identity_key,

--- a/server/rag/pipeline/tests/test_user_memory.py
+++ b/server/rag/pipeline/tests/test_user_memory.py
@@ -1,11 +1,15 @@
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
 
 from pipeline.memory.user_memory import (
+    DEFAULT_USER_MEMORY_TTL_SECONDS,
     InMemoryUserMemoryStore,
+    RedisUserMemoryStore,
     _identity_key,
+    _merge_memory,
 )
 
 
@@ -33,3 +37,90 @@ def test_user_memory_ignores_guest_identity():
     assert _identity_key(guest) is None
     assert store.merge(guest, "Do not persist this.") == ""
     assert store.get(guest) == ""
+
+
+def test_identity_key_prefers_stable_erp_id_over_email():
+    with_email = {
+        "role": "student",
+        "email": "student@dau.ac.in",
+        "erp_id": "202401001",
+    }
+    without_email = {
+        "role": "student",
+        "erp_id": "202401001",
+    }
+
+    assert _identity_key(with_email) == _identity_key(without_email)
+
+
+def test_merge_replaces_evolving_summary_for_same_thread():
+    existing = _merge_memory("", "S1: User is comparing electives.")
+    merged = _merge_memory(
+        existing,
+        "S1: User is comparing electives and wants a timetable-safe option.",
+        "S1: User is comparing electives.",
+    )
+
+    assert "timetable-safe option" in merged
+    assert merged.count("## Prior Thread Memory") == 1
+    assert "S1: User is comparing electives.\n" not in merged
+
+
+def test_redis_user_memory_get_soft_fails_when_redis_is_down():
+    import redis
+
+    client = MagicMock()
+    client.get.side_effect = redis.RedisError("redis down")
+    with patch("redis.Redis.from_url", return_value=client):
+        store = RedisUserMemoryStore("redis://localhost:6379/0")
+
+    assert store.get({"role": "student", "erp_id": "202401001"}) == ""
+
+
+def test_redis_user_memory_merge_soft_fails_when_redis_is_down():
+    import redis
+
+    client = MagicMock()
+    client.pipeline.side_effect = redis.RedisError("redis down")
+    with patch("redis.Redis.from_url", return_value=client):
+        store = RedisUserMemoryStore("redis://localhost:6379/0")
+
+    assert store.merge({"role": "student", "erp_id": "202401001"}, "summary") == ""
+
+
+def test_redis_user_memory_sets_retention_ttl():
+    class FakePipe:
+        def __init__(self):
+            self.set_calls = []
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def watch(self, _key):
+            return None
+
+        def get(self, _key):
+            return ""
+
+        def multi(self):
+            return None
+
+        def set(self, key, value, ex=None):
+            self.set_calls.append((key, value, ex))
+
+        def execute(self):
+            return [True]
+
+    pipe = FakePipe()
+    client = MagicMock()
+    client.pipeline.return_value = pipe
+    with patch("redis.Redis.from_url", return_value=client):
+        store = RedisUserMemoryStore("redis://localhost:6379/0")
+
+    store.merge({"role": "student", "erp_id": "202401001"}, "summary")
+
+    assert pipe.set_calls
+    assert pipe.set_calls[0][2] == DEFAULT_USER_MEMORY_TTL_SECONDS

--- a/server/rag/pipeline/tests/test_user_memory.py
+++ b/server/rag/pipeline/tests/test_user_memory.py
@@ -1,0 +1,30 @@
+from pipeline.memory.user_memory import (
+    InMemoryUserMemoryStore,
+    _identity_key,
+)
+
+
+def test_user_memory_merges_thread_summaries_for_signed_in_user():
+    store = InMemoryUserMemoryStore()
+    identity = {
+        "role": "student",
+        "email": "student@dau.ac.in",
+        "erp_id": "202401001",
+    }
+
+    assert store.get(identity) == ""
+    store.merge(identity, "User prefers concise answers.")
+    store.merge(identity, "User is working on timetable questions.")
+
+    memory = store.get(identity)
+    assert "User prefers concise answers." in memory
+    assert "User is working on timetable questions." in memory
+
+
+def test_user_memory_ignores_guest_identity():
+    store = InMemoryUserMemoryStore()
+    guest = {"role": "guest", "erp_id": "GUEST-123"}
+
+    assert _identity_key(guest) is None
+    assert store.merge(guest, "Do not persist this.") == ""
+    assert store.get(guest) == ""


### PR DESCRIPTION
## Summary
- add Redis-backed persistent user memory for signed-in users
- preserve compressed thread summaries across history sync and continuation threads
- make Redis guest quota increments atomic
- lazy-load local embedding/reranker models when remote services are unavailable

## Test plan
- python py_compile on changed backend files
- git diff --check
- local RedisQuotaStore probe with fake Redis client
- local user memory store probe