### PR TITLE
fix(infra): point CD workflow at deploy/ after path move

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -31,20 +31,20 @@ on:
     paths:
       - "aura/**"
       - "server/**"
-      - ".github/deploy/node1/**"
-      - ".github/deploy/node2/**"
-      - ".github/deploy/node3/**"
-      - ".github/deploy/node4/**"
-      - ".github/deploy/monitoring/**"
-      - ".github/deploy/nginx/**"
-      - ".github/deploy/scripts/deploy-apps.sh"
-      - ".github/deploy/scripts/deploy-node2.sh"
-      - ".github/deploy/scripts/deploy-node3.sh"
-      - ".github/deploy/scripts/deploy-node4.sh"
-      - ".github/deploy/scripts/deploy-cluster.sh"
-      - ".github/deploy/scripts/lib/**"
+      - "deploy/node1/**"
+      - "deploy/node2/**"
+      - "deploy/node3/**"
+      - "deploy/node4/**"
+      - "deploy/monitoring/**"
+      - "deploy/nginx/**"
+      - "deploy/scripts/deploy-apps.sh"
+      - "deploy/scripts/deploy-node2.sh"
+      - "deploy/scripts/deploy-node3.sh"
+      - "deploy/scripts/deploy-node4.sh"
+      - "deploy/scripts/deploy-cluster.sh"
+      - "deploy/scripts/lib/**"
       - "services/**"
-      - ".github/workflows/cd-auto-deploy.yml"
+      - ".github/workflows/cd.yml"
 
 permissions:
   contents: read
@@ -150,7 +150,7 @@ jobs:
           # Deploy tree must match the remote ref exactly. Reset instead of
           # pull --ff-only so stray local edits on the runner (e.g. a hand-edited
           # tracked file) can never abort the deploy. Untracked files such as
-          # .github/deploy/node1/.env are left in place (no git clean).
+          # deploy/node1/.env are left in place (no git clean).
           git checkout -f "${REF}"
           if git show-ref --verify --quiet "refs/remotes/origin/${REF}"; then
             git reset --hard "origin/${REF}"
@@ -189,22 +189,22 @@ jobs:
             else
               changed="$(git diff --name-only "${BEFORE}" "${AFTER}")"
               if printf '%s\n' "${changed}" | grep -E \
-                '^(aura/|server/|.github/deploy/node1/|.github/deploy/scripts/deploy-apps\.sh|.github/deploy/nginx/|\.github/workflows/cd-auto-deploy\.yml)' \
+                '^(aura/|server/|deploy/node1/|deploy/scripts/deploy-apps\.sh|deploy/nginx/|\.github/workflows/cd\.yml)' \
                 >/dev/null; then
                 deploy_apps=true
               fi
               if printf '%s\n' "${changed}" | grep -E \
-                '^(\.github/deploy/node2/|.github/deploy/scripts/deploy-node2\.sh|.github/deploy/scripts/lib/|.github/deploy/scripts/deploy-cluster\.sh)' \
+                '^(deploy/node2/|deploy/scripts/deploy-node2\.sh|deploy/scripts/lib/|deploy/scripts/deploy-cluster\.sh)' \
                 >/dev/null; then
                 deploy_node2=true
               fi
               if printf '%s\n' "${changed}" | grep -E \
-                '^(\.github/deploy/node3/|.github/deploy/scripts/deploy-node3\.sh|.github/deploy/scripts/lib/|.github/deploy/scripts/deploy-cluster\.sh)' \
+                '^(deploy/node3/|deploy/scripts/deploy-node3\.sh|deploy/scripts/lib/|deploy/scripts/deploy-cluster\.sh)' \
                 >/dev/null; then
                 deploy_node3=true
               fi
               if printf '%s\n' "${changed}" | grep -E \
-                '^(\.github/deploy/node4/|.github/deploy/monitoring/|.github/deploy/scripts/deploy-node4\.sh|.github/deploy/scripts/lib/|.github/deploy/scripts/deploy-cluster\.sh|services/)' \
+                '^(deploy/node4/|deploy/monitoring/|deploy/scripts/deploy-node4\.sh|deploy/scripts/lib/|deploy/scripts/deploy-cluster\.sh|services/)' \
                 >/dev/null; then
                 deploy_node4=true
               fi
@@ -249,11 +249,11 @@ jobs:
           export AURA_SSH_KEY
 
           chmod +x \
-            "${AURA_APP_ROOT}/.github/deploy/scripts/deploy-apps.sh" \
-            "${AURA_APP_ROOT}/.github/deploy/scripts/deploy-node2.sh" \
-            "${AURA_APP_ROOT}/.github/deploy/scripts/deploy-node3.sh" \
-            "${AURA_APP_ROOT}/.github/deploy/scripts/deploy-node4.sh" \
-            "${AURA_APP_ROOT}/.github/deploy/scripts/deploy-cluster.sh"
+            "${AURA_APP_ROOT}/deploy/scripts/deploy-apps.sh" \
+            "${AURA_APP_ROOT}/deploy/scripts/deploy-node2.sh" \
+            "${AURA_APP_ROOT}/deploy/scripts/deploy-node3.sh" \
+            "${AURA_APP_ROOT}/deploy/scripts/deploy-node4.sh" \
+            "${AURA_APP_ROOT}/deploy/scripts/deploy-cluster.sh"
 
           args=()
           [[ "${DEPLOY_APPS}" == "true" ]] && args+=(--apps)
@@ -262,7 +262,7 @@ jobs:
           [[ "${DEPLOY_NODE4}" == "true" ]] && args+=(--node4)
 
           echo "==> Running deploy-cluster.sh ${args[*]} ${DEPLOY_REF}"
-          "${AURA_APP_ROOT}/.github/deploy/scripts/deploy-cluster.sh" "${args[@]}" "${DEPLOY_REF}"
+          "${AURA_APP_ROOT}/deploy/scripts/deploy-cluster.sh" "${args[@]}" "${DEPLOY_REF}"
 
       - name: Nothing to deploy
         if: >-

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ graph TB
   L --> E --> RR
 ```
 
-Production multi-node layout, compose files, and CD: [`.github/deploy/README.md`](./.github/deploy/README.md).
+Production multi-node layout, compose files, and CD: [`deploy/README.md`](./deploy/README.md).
 
 ---
 

--- a/deploy/scripts/lib/remote.sh
+++ b/deploy/scripts/lib/remote.sh
@@ -104,14 +104,14 @@ aura_rsync() {
   aura_require_ssh_key
   aura_require_host "${host}" "rsync host"
 
-  # Repo layout: deploy configs live under .github/deploy/. Remote nodes still
+  # Repo layout: deploy configs live under deploy/. Remote nodes still
   # receive them at ${AURA_REMOTE_APP_ROOT}/deploy/ (install path unchanged).
-  local local_deploy="${AURA_APP_ROOT}/.github/deploy"
+  local local_deploy="${AURA_APP_ROOT}/deploy"
   if [[ ! -d "${local_deploy}" ]]; then
-    local_deploy="${AURA_APP_ROOT}/deploy"
+    local_deploy="${AURA_APP_ROOT}/.github/deploy"
   fi
   if [[ ! -d "${local_deploy}" ]]; then
-    echo "error: local deploy missing under ${AURA_APP_ROOT}/.github/deploy (or deploy/)" >&2
+    echo "error: local deploy missing under ${AURA_APP_ROOT}/deploy (or .github/deploy/)" >&2
     return 1
   fi
 


### PR DESCRIPTION
## Summary
- **Root cause:** Commit `74494bf` moved deploy scripts from `.github/deploy/` to `deploy/`, but the CD workflow still `chmod`'d and invoked the old `.github/deploy/scripts/...` paths, so deploys failed.
- **Fix:** Update `.github/workflows/cd.yml` path filters, change-detection greps, and script invocations to `deploy/`; refresh the README link; prefer `deploy/` over `.github/deploy/` in `remote.sh`.

## Test plan
- [ ] After merge, re-run CD via `workflow_dispatch` with all-safe (or apps) and confirm scripts resolve under `deploy/scripts/`
- [ ] Confirm path filters / change detection still select the expected node deploys when those trees change


Made with [Cursor](https://cursor.com)