### PR TITLE
fix(infra): correct node1 build context depth after deploy/ move

### DIFF
--- a/deploy/node1/docker-compose.yml
+++ b/deploy/node1/docker-compose.yml
@@ -48,7 +48,7 @@ services:
 
   aura:
     build:
-      context: ../aura
+      context: ../../aura
       dockerfile: Dockerfile
     restart: unless-stopped
     expose:
@@ -72,7 +72,7 @@ services:
 
   backend:
     build:
-      context: ../server
+      context: ../../server
       dockerfile: Dockerfile
     restart: unless-stopped
     expose:


### PR DESCRIPTION
## Summary

Node 1 application deploy (`deploy-cluster.sh --apps`) fails at the build step with:

```
unable to prepare context: path "/opt/aura/app/deploy/aura" not found
error: [cluster] Node 1 applications failed (exit 1)
```

`deploy/scripts/deploy-apps.sh` runs `docker compose up --build` from `deploy/node1/`, so Compose resolves build contexts relative to that directory. `deploy/node1/docker-compose.yml` was copied from `deploy/docker-compose.prod.yml` (one level under the repo root, where `../aura` is correct) into `deploy/node1/` (two levels down) without adjusting depth — so `../aura` / `../server` pointed at the non-existent `deploy/aura` and `deploy/server`.

Fix: point both contexts at the repo-root dirs via `../../aura` and `../../server`.

## Test plan

- `docker compose --env-file .env.node1.example config` now resolves:
  - `context: <repo>/aura`
  - `context: <repo>/server`
  (both exist and contain `Dockerfile`)
- On the host these become `/opt/aura/app/aura` and `/opt/aura/app/server` ✓
- `deploy/docker-compose.prod.yml` (at `deploy/`) and `deploy/node4/docker-compose.yml` (uses `../../services/...`) were checked and are already correct — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)