### PR TITLE
fix(infra): point node1 nginx mount at deploy/nginx/nginx.conf

### DIFF
--- a/deploy/node1/docker-compose.yml
+++ b/deploy/node1/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      - ../nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./certs:/etc/nginx/certs:ro
     depends_on:
       aura:


### PR DESCRIPTION
## Summary

The `CD — Aura GPU cluster deploy` workflow is failing at the **Refreshing nginx** stage for `aura-node1` with:

```
error mounting "/opt/aura/app/deploy/node1/nginx.conf" to rootfs at "/etc/nginx/nginx.conf":
... not a directory: Are you trying to mount a directory onto a file (or vice-versa)?
```

**Root cause:** `deploy/node1/docker-compose.yml` bind-mounted `./nginx.conf`, which resolves to `deploy/node1/nginx.conf` — a path that never existed. The `deploy/` restructure moved the Node 1 reverse-proxy config to `deploy/nginx/nginx.conf` (as documented in `deploy/README.md` and watched by the CD workflow's `deploy/nginx/**` path filter) but left the compose mount pointing at the old sibling path. With the source missing, Docker auto-creates it as a directory, then fails to bind a directory onto the file `/etc/nginx/nginx.conf`.

## Change

Repoint the nginx mount from `./nginx.conf` to `../nginx/nginx.conf` so it resolves to the real config file and matches the documented layout. One line, `deploy/node1/docker-compose.yml` only.

## Test plan

- `docker compose --env-file .env.node1.example config` now resolves the mount source to `.../deploy/nginx/nginx.conf`, an existing 8791-byte file (previously a non-existent path auto-created as a directory).
- On the host this maps to `/opt/aura/app/deploy/nginx/nginx.conf`, so the `nginx` container's bind-mount onto `/etc/nginx/nginx.conf` will succeed and the CD "Refreshing nginx" stage will pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)