### PR TITLE
fix(infra): correct node1 bind mounts after deploy/ move

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -230,6 +230,9 @@ jobs:
           AURA_APP_ROOT: /opt/aura/app
           AURA_ENV_FILE: /opt/aura/app/deploy/node1/.env
           GITHUB_TOKEN: ${{ secrets.AURA_DEPLOY_GIT_TOKEN || github.token }}
+          # Host/SSH settings: prefer non-empty GitHub Actions vars; empty vars
+          # stay empty so deploy/scripts/lib/remote.sh can fill from
+          # deploy/node1/.env (intentional fallback).
           AURA_NODE2_HOST: ${{ vars.AURA_NODE2_HOST }}
           AURA_NODE3_HOST: ${{ vars.AURA_NODE3_HOST }}
           AURA_NODE4_HOST: ${{ vars.AURA_NODE4_HOST }}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -117,7 +117,7 @@ On **Node 1**:
 cd deploy/node1
 cp .env.node1.example .env
 # Edit .env and replace <NODE_2_IP>, <NODE_3_IP>, <NODE_4_IP> with actual LAN IPs!
-mkdir -p ../certs # add fullchain.pem / privkey.pem
+mkdir -p ./certs # add fullchain.pem / privkey.pem (mounted as ./certs in compose)
 docker compose up -d --build
 ```
 
@@ -323,8 +323,10 @@ Orchestrator: [`deploy/scripts/deploy-cluster.sh`](scripts/deploy-cluster.sh)
 /opt/aura/app/deploy/scripts/deploy-cluster.sh --node4
 ```
 
-Set `AURA_NODE{2,3,4}_HOST` in `deploy/node1/.env` (or GitHub Actions variables).
-Optional per-node SSH users: `AURA_NODE{2,3,4}_SSH_USER`.
+Set `AURA_NODE{2,3,4}_HOST` in `deploy/node1/.env` (preferred) and/or GitHub
+Actions repository variables. Empty Actions variables do not block the `.env`
+fallback — scripts only keep non-empty exported values. Optional per-node SSH
+users: `AURA_NODE{2,3,4}_SSH_USER`.
 
 `deploy-apps.sh` uses `docker compose up -d --build --no-deps aura backend` so
 database containers are not touched. `deploy-node4.sh` uses

--- a/deploy/node1/docker-compose.yml
+++ b/deploy/node1/docker-compose.yml
@@ -21,12 +21,12 @@
 # match host GPU indices. Single GPU: run only node1 and set one endpoint.
 #
 # Usage:
-#   cp deploy/.env.prod.example deploy/.env.prod   # fill in secrets
-#   mkdir -p deploy/certs && # add fullchain.pem / privkey.pem
+#   cp deploy/node1/.env.node1.example deploy/node1/.env   # fill in secrets
+#   mkdir -p deploy/node1/certs && # add fullchain.pem / privkey.pem
 #   # Core stack (no host GPUs required):
-#   docker compose -f deploy/docker-compose.prod.yml --env-file deploy/.env.prod up -d --build
+#   docker compose -f deploy/node1/docker-compose.yml --env-file deploy/node1/.env up -d --build
 #   # With local vLLM GPU nodes:
-#   docker compose -f deploy/docker-compose.prod.yml --env-file deploy/.env.prod --profile gpu up -d --build
+#   docker compose -f deploy/node1/docker-compose.yml --env-file deploy/node1/.env --profile gpu up -d --build
 
 services:
   nginx:
@@ -37,6 +37,7 @@ services:
       - "443:443"
     volumes:
       - ../nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      # TLS material stays on Node 1 under deploy/node1/certs/ (not rsynced).
       - ./certs:/etc/nginx/certs:ro
     depends_on:
       aura:
@@ -103,8 +104,8 @@ services:
       ECAMPUS_TIMETABLE_POOL_DB: /var/lib/aura/timetable_pool.db
       AURA_AUDIT_LOG: /var/log/aura/personal_data_audit.log
     volumes:
-      # Raw markdown knowledge base — /documents + ad-hoc ingestion.
-      - ../data:/app/data:ro
+      # Raw markdown knowledge base — repo-root data/ (two levels up from node1/).
+      - ../../data:/app/data:ro
       - aura-vault:/var/lib/aura
       - aura-logs:/var/log/aura
     # Note: do NOT depends_on vllm-node* here — those services use profile
@@ -262,7 +263,7 @@ services:
     image: prom/prometheus:latest
     restart: unless-stopped
     volumes:
-      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ../monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus-data:/prometheus
     expose:
       - "9090"
@@ -279,7 +280,7 @@ services:
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
     volumes:
       - grafana-data:/var/lib/grafana
-      - ./monitoring/grafana-datasource.yml:/etc/grafana/provisioning/datasources/prometheus.yml:ro
+      - ../monitoring/grafana-datasource.yml:/etc/grafana/provisioning/datasources/prometheus.yml:ro
     expose:
       - "3000"
     depends_on:

--- a/deploy/scripts/deploy-apps.sh
+++ b/deploy/scripts/deploy-apps.sh
@@ -66,6 +66,26 @@ if [[ ! -f "${COMPOSE_DIR}/docker-compose.yml" ]]; then
   exit 1
 fi
 
+# Fail fast on stale/missing paths left over from the deploy/ layout move.
+require_path() {
+  local path="$1"
+  local kind="$2"
+  if [[ "${kind}" == "dir" ]]; then
+    if [[ ! -d "${path}" ]]; then
+      echo "error: required directory missing: ${path}" >&2
+      exit 1
+    fi
+  elif [[ ! -f "${path}" ]]; then
+    echo "error: required file missing: ${path}" >&2
+    exit 1
+  fi
+}
+require_path "${APP_ROOT}/aura" dir
+require_path "${APP_ROOT}/server" dir
+require_path "${APP_ROOT}/data" dir
+require_path "${APP_ROOT}/deploy/nginx/nginx.conf" file
+require_path "${APP_ROOT}/deploy/monitoring/prometheus.yml" file
+
 # Self-hosted runners have no interactive HTTPS credentials. Prefer either:
 #   - GITHUB_TOKEN / GH_TOKEN in the environment (CD workflow), or
 #   - SSH remote + read-only deploy key on the host (manual deploys).

--- a/deploy/scripts/lib/remote.sh
+++ b/deploy/scripts/lib/remote.sh
@@ -108,10 +108,12 @@ aura_rsync() {
   # receive them at ${AURA_REMOTE_APP_ROOT}/deploy/ (install path unchanged).
   local local_deploy="${AURA_APP_ROOT}/deploy"
   if [[ ! -d "${local_deploy}" ]]; then
-    local_deploy="${AURA_APP_ROOT}/.github/deploy"
+    echo "error: local deploy tree missing: ${local_deploy}" >&2
+    echo "  Expected layout after the deploy/ move (not .github/deploy/)." >&2
+    return 1
   fi
-  if [[ ! -d "${local_deploy}" ]]; then
-    echo "error: local deploy missing under ${AURA_APP_ROOT}/deploy (or .github/deploy/)" >&2
+  if [[ ! -f "${local_deploy}/node1/docker-compose.yml" ]]; then
+    echo "error: expected ${local_deploy}/node1/docker-compose.yml not found" >&2
     return 1
   fi
 
@@ -162,7 +164,6 @@ aura_rsync() {
 aura_load_node1_env() {
   local candidates=(
     "${AURA_ENV_FILE:-}"
-    "${AURA_APP_ROOT}/.github/deploy/node1/.env"
     "${AURA_APP_ROOT}/deploy/node1/.env"
     "/opt/aura/.env"
   )

--- a/server/api/api.py
+++ b/server/api/api.py
@@ -77,7 +77,7 @@ from fastapi import Response
 from api.metrics import REQUEST_COUNT, REQUEST_LATENCY, STAGE_LATENCY, metrics_response
 
 # ── Prometheus scrape endpoint (architecture doc: aura-prometheus) ────────
-# Never routed through the public NGINX edge — see .github/deploy/nginx.conf, which
+# Never routed through the public NGINX edge — see deploy/nginx/nginx.conf, which
 # only proxies /api/*, /backend/, and /. Prometheus scrapes this container
 # directly over the internal Docker network.
 @app.get("/metrics")

--- a/server/api/metrics.py
+++ b/server/api/metrics.py
@@ -21,7 +21,7 @@
 
 # `/metrics` is intentionally unauthenticated (Prometheus scrapes it directly,
 # container-to-container, and it is never routed through the public NGINX
-# edge — see .github/deploy/nginx.conf, which only proxies /api/*, /backend/, and /).
+# edge — see deploy/nginx/nginx.conf, which only proxies /api/*, /backend/, and /).
 
 from prometheus_client import (
     Counter,

--- a/server/rag/.env.example
+++ b/server/rag/.env.example
@@ -62,7 +62,7 @@ ECAMPUS_BASE_URL=https://ecampus.daiict.ac.in
 ECAMPUS_TIMETABLE_POOL_DB=/var/lib/aura/timetable_pool.db
 
 # Vector Knowledge Base
-# Node 4 embedding-reranker (.github/deploy/node4) — port 8001, not legacy TEI :8081
+# Node 4 embedding-reranker (deploy/node4) — port 8001, not legacy TEI :8081
 EMBEDDING_URL=http://10.100.97.74:8001
 EMBEDDING_SERVICE_URL=http://10.100.97.74:8001
 QDRANT_URL=http://10.100.97.74:6333

--- a/server/rag/pipeline/memory/conversation_memory.py
+++ b/server/rag/pipeline/memory/conversation_memory.py
@@ -142,7 +142,7 @@ class MemoryResult:
 class ConversationMemory:
     def __init__(self, summariser: Optional[Summariser] = None):
         # vLLM is launched with `--max-model-len ${MAX_MODEL_LEN:-8192}`
-        # (.github/deploy/node*/docker-compose.yml), so read the same env var to stay in
+        # (deploy/node*/docker-compose.yml), so read the same env var to stay in
         # lockstep with whatever the running pool actually accepts.
         self.model_context_tokens = _env_int("MAX_MODEL_LEN", 8192)
         self.reserved_answer = _env_int("AURA_MAX_ANSWER_TOKENS", 768)


### PR DESCRIPTION
## Summary
- Fix residual `deploy/node1` bind mounts broken by the `.github/deploy` → `deploy/` move: `../../data` (was `../data` → empty `deploy/data`) and `../monitoring/*` (was `./monitoring/*` under node1).
- Harden `deploy-apps.sh` / `remote.sh` to fail fast if expected `deploy/` paths are missing; drop stale `.github/deploy` env fallback priority.
- Docs/comments: certs path, empty GH Actions vars → `.env` fallback, and stale `.github/deploy` references.

## Test plan
- [ ] Confirm compose path resolution: from `deploy/node1/`, `../../data`, `../nginx/nginx.conf`, `../monitoring/prometheus.yml` exist in the checkout
- [ ] After merge, Node 1 CD apps deploy succeeds (paths filter on `deploy/node1/**`)
- [ ] Backend container mounts real repo `data/` (not an empty `deploy/data` dir Docker may have auto-created)
- [ ] Optional: on Node 1, `rmdir /opt/aura/app/deploy/data` if it is an empty leftover from the bad mount


Made with [Cursor](https://cursor.com)