### PR TITLE
fix(infra,rag,bff): resolve NGINX 502 upstream resolution, clarify club convenor classification, and forward backend status codes

### DIFF
--- a/aura/app/api/chat/route.ts
+++ b/aura/app/api/chat/route.ts
@@ -205,7 +205,10 @@ async function handleChatPost(req: Request): Promise<Response> {
   if (!backendRes.ok) {
     const text = await backendRes.text().catch(() => "")
     console.error("[chat] backend error:", backendRes.status, text)
-    return new Response("Backend error", { status: 502 })
+    return new Response(text || backendRes.statusText || "Backend error", {
+      status: backendRes.status,
+      headers: { "Content-Type": backendRes.headers.get("Content-Type") || "text/plain" },
+    })
   }
 
   if (!backendRes.body) {

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -118,6 +118,7 @@ services:
       qdrant:
         condition: service_healthy
     networks:
+      - aura-edge
       - aura-internal
 
   postgres:

--- a/deploy/node1/docker-compose.yml
+++ b/deploy/node1/docker-compose.yml
@@ -118,6 +118,7 @@ services:
       qdrant:
         condition: service_healthy
     networks:
+      - aura-edge
       - aura-internal
 
   postgres:

--- a/server/rag/personal_query_classifier.py
+++ b/server/rag/personal_query_classifier.py
@@ -21,11 +21,12 @@ Classify the query into one of four types:
 
 PUBLIC: Answer is in public university documents — policies, course catalogs,
 events, faculty research profiles, placement aggregate stats, scholarship
-rules (not a specific student's eligibility), general campus info.
+rules (not a specific student's eligibility), general campus info, student clubs,
+club convenors, club leadership/structure, and student organizations (e.g. "Who is the convenor of AI Club?").
 
 PERSONAL: Requires looking up a specific person's private record:
   For STUDENTS — CGPA, attendance, grades, fees, hostel allotment, BTP status,
-    enrollment status, timetable, transcript, club memberships.
+    enrollment status, timetable, transcript, personal private club membership status/dues of an individual student (NOT public club convenors or general club leadership).
   For FACULTY — their own teaching schedule, BTP students under them,
     exploration project mentees, office hour slots, course student list,
     CPDA/leave status, payslip, assigned exam duties.


### PR DESCRIPTION
### Summary of Changes

1. **Infrastructure (NGINX 502 Fix)**:
   - Attached `backend` service to `aura-edge` network in `deploy/node1/docker-compose.yml` and `deploy/docker-compose.prod.yml`.
   - Ensures NGINX can resolve `backend:8000` on the `aura-edge` network and stops NGINX crash-looping (`[emerg] host not found in upstream "backend:8000"`).

2. **RAG Classifier (Club Convenor Fix)**:
   - Updated `CLASSIFIER_PROMPT` in `server/rag/personal_query_classifier.py`.
   - Explicitly clarified that public university student clubs, convenors, and student organizations (e.g. "Who is the convenor of AI Club?") are `PUBLIC` directory queries, preventing erroneous misrouting to private student ERP tables.

3. **BFF Error Pass-Through (Next.js Proxy)**:
   - Updated `aura/app/api/chat/route.ts` to forward real backend HTTP status codes (e.g., 400, 422, 500) and response bodies directly to the browser client instead of forcing a blanket 502 status rewrite.
