### PR TITLE
fix(rag): support Arabic/Roman semester canonicalization and student login program scope

### DIFF
--- a/server/rag/pipeline/retrieval/retrieval_pipeline.py
+++ b/server/rag/pipeline/retrieval/retrieval_pipeline.py
@@ -229,6 +229,37 @@ class RetrievalPipeline:
                 
         return query
 
+    @staticmethod
+    def _canonical_semester_values(semester_raw):
+        if not semester_raw:
+            return []
+        sem_str = str(semester_raw).strip()
+        arabic_to_roman = {
+            "1": "I", "2": "II", "3": "III", "4": "IV",
+            "5": "V", "6": "VI", "7": "VII", "8": "VIII"
+        }
+        roman_to_arabic = {v: k for k, v in arabic_to_roman.items()}
+        m_digit = re.search(r"\b([1-8])\b", sem_str)
+        m_roman = re.search(r"\b(VIII|VII|VI|V|IV|III|II|I)\b", sem_str, re.IGNORECASE)
+        digit = m_digit.group(1) if m_digit else None
+        roman = m_roman.group(1).upper() if m_roman else None
+        if not digit and roman:
+            digit = roman_to_arabic.get(roman)
+        elif digit and not roman:
+            roman = arabic_to_roman.get(digit)
+        variants = []
+        if roman:
+            variants.extend([f"Semester {roman}", roman])
+        if digit:
+            variants.extend([f"Semester {digit}", f"Sem {digit}", digit])
+        seen = set()
+        out = []
+        for v in variants:
+            if v not in seen:
+                seen.add(v)
+                out.append(v)
+        return out or [sem_str]
+
     def _build_metadata_filter(
         self,
         plan
@@ -318,14 +349,18 @@ class RetrievalPipeline:
             )
         )
 
-        if program_name and semester:
-            prog_clause = as_filter("program_name", program_name)
-            return {
-                "$and": [
-                    prog_clause,
-                    {"semester": {"$eq": semester}}
-                ]
-            }
+        if semester:
+            sem_vals = self._canonical_semester_values(semester)
+            sem_clause = {"semester": {"$in": sem_vals}} if len(sem_vals) > 1 else {"semester": {"$eq": sem_vals[0]}}
+            if program_name:
+                prog_clause = as_filter("program_name", program_name)
+                return {
+                    "$and": [
+                        prog_clause,
+                        sem_clause
+                    ]
+                }
+            return sem_clause
 
         if program_name:
             return as_filter("program_name", program_name)
@@ -560,6 +595,14 @@ class RetrievalPipeline:
         )
 
         plan = future_plan.result()
+
+        # Infer user program from academic_scope if available and not present in plan entities
+        if academic_scope and getattr(academic_scope, "programme_id", None):
+            entities = plan.setdefault("entities", {})
+            if not entities.get("program_name"):
+                inferred_prog = self._canonical_program_name(academic_scope.programme_id)
+                if inferred_prog:
+                    entities["program_name"] = inferred_prog
 
         # Check if the plan contains anything that modifies retrieval or query
         entities = plan.get("entities", {})


### PR DESCRIPTION
### Summary of Changes

Resolves zero-chunk retrieval failures for semester curriculum queries (e.g. `"list down the subjects and electives of sem 5"`):

1. **Semester Canonicalization & Equivalence Mapping**:
   - Added `_canonical_semester_values(semester)` to [server/rag/pipeline/retrieval/retrieval_pipeline.py](file:///Users/vedant_shah/Desktop/DAU-pwa/server/rag/pipeline/retrieval/retrieval_pipeline.py#L230).
   - Maps any semester representation (`"5"`, `"sem 5"`, `"semester 5"`, `"V"`, `"Semester V"`) into an `$in` array matching all equivalent dataset representations (`["Semester V", "V", "Semester 5", "Sem 5", "5"]`).

2. **Standalone Semester Filter Support for Guest Users**:
   - Updated `_build_metadata_filter()` so queries without an explicit `program_name` still filter by `semester`, allowing guest users to retrieve curriculum subjects instead of triggering an empty-retrieval canned error.

3. **Logged-In Student Program Scope Inference**:
   - Updated `get_context()` to automatically infer `program_name` from the authenticated user's `academic_scope` (e.g. `B.Tech. (ICT)`) when unstated in the query entities.
