### PR TITLE
feat(monitoring): auto-provision Grafana dashboards and add host/GPU telemetry scrape targets

### DIFF
--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -295,6 +295,8 @@ services:
     volumes:
       - grafana-data:/var/lib/grafana
       - ./monitoring/grafana-datasource.yml:/etc/grafana/provisioning/datasources/prometheus.yml:ro
+      - ./monitoring/grafana-dashboards.yml:/etc/grafana/provisioning/dashboards/dashboards.yml:ro
+      - ./monitoring/dashboards:/etc/grafana/provisioning/dashboards:ro
     expose:
       - "3000"
     depends_on:

--- a/deploy/monitoring/dashboards/aura-system-overview.json
+++ b/deploy/monitoring/dashboards/aura-system-overview.json
@@ -1,0 +1,145 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 0 },
+      "id": 1,
+      "title": "Backend Request Rate (RPS)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "Prometheus" },
+          "expr": "sum(rate(aura_http_requests_total[1m])) by (status)",
+          "legendFormat": "HTTP {{status}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 0 },
+      "id": 2,
+      "title": "Request Latency P95 (Seconds)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "Prometheus" },
+          "expr": "histogram_quantile(0.95, sum(rate(aura_http_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "P95 Latency",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 0 },
+      "id": 3,
+      "title": "RAG Pipeline Stage Latency (Avg)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "Prometheus" },
+          "expr": "sum(rate(aura_chat_stage_duration_seconds_sum[5m])) by (stage) / sum(rate(aura_chat_stage_duration_seconds_count[5m])) by (stage)",
+          "legendFormat": "Stage: {{stage}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 0 },
+      "id": 4,
+      "title": "vLLM Dispatched Requests per Node",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "Prometheus" },
+          "expr": "sum(rate(aura_inference_node_requests_total[1m])) by (node)",
+          "legendFormat": "Node: {{node}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 8 },
+      "id": 5,
+      "title": "NGINX Edge Load by Route",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "Prometheus" },
+          "expr": "sum(rate(nginx_http_requests_total[1m])) by (request_uri)",
+          "legendFormat": "Route: {{request_uri}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 8 },
+      "id": 6,
+      "title": "vLLM Inference Engine Queue & Running Requests",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "Prometheus" },
+          "expr": "vllm:num_requests_running",
+          "legendFormat": "Running Requests",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "Prometheus" },
+          "expr": "vllm:num_requests_waiting",
+          "legendFormat": "Waiting Queue",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 8 },
+      "id": 7,
+      "title": "vLLM Token Generation Speed (Tok/s)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "Prometheus" },
+          "expr": "vllm:avg_generation_throughput_tok_per_s",
+          "legendFormat": "Tok/s",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["aura", "monitoring"],
+  "time": { "from": "now-30m", "to": "now" },
+  "timepicker": {
+    "refresh_intervals": ["5s", "10s", "30s", "1m"]
+  },
+  "timezone": "browser",
+  "title": "AURA System Observability",
+  "uid": "aura-system-overview",
+  "version": 1
+}

--- a/deploy/monitoring/grafana-dashboards.yml
+++ b/deploy/monitoring/grafana-dashboards.yml
@@ -1,0 +1,12 @@
+# Auto-provisions dashboard JSON files from /etc/grafana/provisioning/dashboards
+apiVersion: 1
+
+providers:
+  - name: 'AURA Dashboards'
+    orgId: 1
+    folder: 'AURA Monitoring'
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/deploy/monitoring/prometheus.yml
+++ b/deploy/monitoring/prometheus.yml
@@ -9,10 +9,9 @@ scrape_configs:
   # Node 1: FastAPI Gateway & LangGraph Orchestrator
   - job_name: "node1-gateway-backend"
     static_configs:
-      - targets: ["<NODE_1_IP>:8000"]
+      - targets: ["10.100.97.71:8000"]
 
-  # Node 1: nginx edge — per-endpoint request rate + latency
-  # (prometheus-nginxlog-exporter, LAN-published on node 1).
+  # Node 1: NGINX Edge Proxy (prometheus-nginxlog-exporter)
   - job_name: "node1-nginx-edge"
     static_configs:
       - targets: ["10.100.97.71:9113"]
@@ -21,10 +20,26 @@ scrape_configs:
   - job_name: "vllm-inference-nodes"
     static_configs:
       - targets:
-          - "<NODE_2_IP>:8000"
-          - "<NODE_3_IP>:8000"
+          - "10.100.97.72:8000"
+          - "10.100.97.73:8000"
         labels:
           pool: "inference"
+
+  # Host Hardware Telemetry (Node Exporter)
+  - job_name: "node-exporter"
+    static_configs:
+      - targets:
+          - "10.100.97.71:9100"
+          - "10.100.97.72:9100"
+          - "10.100.97.73:9100"
+          - "10.100.97.74:9100"
+
+  # NVIDIA GPU Telemetry (DCGM Exporter)
+  - job_name: "dcgm-exporter"
+    static_configs:
+      - targets:
+          - "10.100.97.72:9400"
+          - "10.100.97.73:9400"
 
   # Node 4: Local Embedding & Reranker Microservice
   - job_name: "node4-embedding-reranker"

--- a/deploy/node1/docker-compose.yml
+++ b/deploy/node1/docker-compose.yml
@@ -312,6 +312,8 @@ services:
     volumes:
       - grafana-data:/var/lib/grafana
       - ../monitoring/grafana-datasource.yml:/etc/grafana/provisioning/datasources/prometheus.yml:ro
+      - ../monitoring/grafana-dashboards.yml:/etc/grafana/provisioning/dashboards/dashboards.yml:ro
+      - ../monitoring/dashboards:/etc/grafana/provisioning/dashboards:ro
     expose:
       - "3000"
     depends_on:

--- a/deploy/node4/docker-compose.yml
+++ b/deploy/node4/docker-compose.yml
@@ -93,6 +93,8 @@ services:
     volumes:
       - grafana-data:/var/lib/grafana
       - ../monitoring/grafana-datasource.yml:/etc/grafana/provisioning/datasources/prometheus.yml:ro
+      - ../monitoring/grafana-dashboards.yml:/etc/grafana/provisioning/dashboards/dashboards.yml:ro
+      - ../monitoring/dashboards:/etc/grafana/provisioning/dashboards:ro
     depends_on:
       - prometheus
     networks:


### PR DESCRIPTION
### Summary of Changes

Configures Grafana dashboard auto-provisioning and completes Prometheus scrape targets across all four infrastructure nodes:

1. **Auto-Provisioned Grafana Dashboard (`aura-system-overview.json`)**:
   - Added [deploy/monitoring/dashboards/aura-system-overview.json](file:///Users/vedant_shah/Desktop/DAU-pwa/deploy/monitoring/dashboards/aura-system-overview.json) containing real-time visualizations for:
     - Backend HTTP Request Rate (RPS) by status code
     - End-to-End P95 Request Latency (seconds)
     - RAG Pipeline Stage Latency Breakdown (guardrail, retrieval, generation)
     - vLLM Dispatched Requests per Node
     - NGINX Edge Load Distribution per Route Bucket
     - vLLM Running Requests & Waiting Queue Length
     - vLLM Token Generation Speed (Tokens/Second)
   - Added [deploy/monitoring/grafana-dashboards.yml](file:///Users/vedant_shah/Desktop/DAU-pwa/deploy/monitoring/grafana-dashboards.yml) to auto-load all JSON dashboards on Grafana startup without manual click-ops.

2. **Expanded Prometheus Scrape Configuration**:
   - Updated [deploy/monitoring/prometheus.yml](file:///Users/vedant_shah/Desktop/DAU-pwa/deploy/monitoring/prometheus.yml) with exact node LAN IPs and added scrape jobs for `node-exporter` (host CPU/RAM/Disk on `:9100`) and `dcgm-exporter` (NVIDIA GPU utilization on `:9400`).

3. **Docker Compose Volume Bind Mounts**:
   - Updated `deploy/node4/docker-compose.yml`, `deploy/node1/docker-compose.yml`, and `deploy/docker-compose.prod.yml` to mount the dashboard provisioning files into `/etc/grafana/provisioning/dashboards`.
