### PR TITLE
feat(monitoring): instrument embedding-reranker microservice with Prometheus metrics

### DIFF
--- a/.github/deploy/monitoring/prometheus.yml
+++ b/.github/deploy/monitoring/prometheus.yml
@@ -43,7 +43,7 @@ scrape_configs:
 
   # Node 4: Local Embedding & Reranker Microservice
   - job_name: "node4-embedding-reranker"
-    metrics_path: /health
+    metrics_path: /metrics
     static_configs:
       - targets: ["embedding-reranker:8001"]
 

--- a/services/embedding-reranker/app/main.py
+++ b/services/embedding-reranker/app/main.py
@@ -1,4 +1,5 @@
 import os
+import time
 import logging
 import threading
 from typing import Annotated, List
@@ -8,7 +9,14 @@ from pydantic import BaseModel, Field
 import torch
 from sentence_transformers import SentenceTransformer
 from transformers import AutoTokenizer, AutoModelForSequenceClassification
-from starlette.responses import JSONResponse
+from starlette.responses import JSONResponse, Response
+from prometheus_client import (
+    Counter,
+    Histogram,
+    Gauge,
+    generate_latest,
+    CONTENT_TYPE_LATEST,
+)
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("embedding-reranker-service")
@@ -17,6 +25,44 @@ app = FastAPI(
     title="AURA Embedding & Reranker Service",
     description="Standalone microservice for Node 4 hosting dense embeddings (BGE-M3) and cross-encoder reranking (BGE-Reranker-v2-m3).",
     version="1.0.0"
+)
+
+# ── Prometheus Instrumentation Metrics ───────────────────────────────────────
+EMBED_REQUESTS_TOTAL = Counter(
+    "tei_embedding_requests_total",
+    "Total embedding HTTP requests handled",
+    ["status_code"]
+)
+RERANK_REQUESTS_TOTAL = Counter(
+    "tei_rerank_requests_total",
+    "Total rerank HTTP requests handled",
+    ["status_code"]
+)
+EMBED_LATENCY = Histogram(
+    "tei_embedding_duration_seconds",
+    "Embedding processing latency in seconds",
+    buckets=[0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0]
+)
+RERANK_LATENCY = Histogram(
+    "tei_rerank_duration_seconds",
+    "Reranking processing latency in seconds",
+    buckets=[0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0]
+)
+DOCUMENTS_EMBEDDED_TOTAL = Counter(
+    "tei_documents_embedded_total",
+    "Total individual text documents encoded by embedding model"
+)
+DOCUMENTS_RERANKED_TOTAL = Counter(
+    "tei_documents_reranked_total",
+    "Total document pairs reranked by cross-encoder model"
+)
+ACTIVE_INFERENCE_REQUESTS = Gauge(
+    "tei_active_requests",
+    "Number of active inference requests currently running"
+)
+SEMAPHORE_AVAILABLE = Gauge(
+    "tei_semaphore_available",
+    "Available capacity in the inference concurrency semaphore"
 )
 
 # Configuration from Environment
@@ -118,16 +164,28 @@ def health_check():
     }
 
 
+@app.get("/metrics")
+def metrics():
+    SEMAPHORE_AVAILABLE.set(_inference_sem._value)
+    return Response(content=generate_latest(), media_type=CONTENT_TYPE_LATEST)
+
+
 @app.post("/embed", response_model=EmbedResponse)
 def embed_texts(req: EmbedRequest):
     if not embedding_model:
+        EMBED_REQUESTS_TOTAL.labels(status_code="503").inc()
         raise HTTPException(status_code=503, detail="Embedding model not loaded")
     if not req.texts:
+        EMBED_REQUESTS_TOTAL.labels(status_code="200").inc()
         return EmbedResponse(embeddings=[], model=EMBEDDING_MODEL_NAME, dimension=0)
 
     acquired = _inference_sem.acquire(blocking=False)
     if not acquired:
+        EMBED_REQUESTS_TOTAL.labels(status_code="503").inc()
         raise HTTPException(status_code=503, detail="Embedding service busy — retry shortly")
+
+    start_time = time.monotonic()
+    ACTIVE_INFERENCE_REQUESTS.inc()
     try:
         embeddings = embedding_model.encode(
             req.texts,
@@ -135,6 +193,12 @@ def embed_texts(req: EmbedRequest):
             convert_to_numpy=True
         ).tolist()
         dimension = len(embeddings[0]) if embeddings else 0
+        
+        duration = time.monotonic() - start_time
+        EMBED_LATENCY.observe(duration)
+        EMBED_REQUESTS_TOTAL.labels(status_code="200").inc()
+        DOCUMENTS_EMBEDDED_TOTAL.inc(len(req.texts))
+
         return EmbedResponse(
             embeddings=embeddings,
             model=EMBEDDING_MODEL_NAME,
@@ -142,21 +206,29 @@ def embed_texts(req: EmbedRequest):
         )
     except Exception as e:
         logger.error(f"Embedding error: {e}")
+        EMBED_REQUESTS_TOTAL.labels(status_code="500").inc()
         raise HTTPException(status_code=500, detail="Embedding failed")
     finally:
+        ACTIVE_INFERENCE_REQUESTS.dec()
         _inference_sem.release()
 
 
 @app.post("/rerank", response_model=RerankResponse)
 def rerank_pairs(req: RerankPairRequest):
     if not reranker_model or not reranker_tokenizer:
+        RERANK_REQUESTS_TOTAL.labels(status_code="503").inc()
         raise HTTPException(status_code=503, detail="Reranker model not loaded")
     if not req.pairs:
+        RERANK_REQUESTS_TOTAL.labels(status_code="200").inc()
         return RerankResponse(scores=[], model=RERANKER_MODEL_NAME)
 
     acquired = _inference_sem.acquire(blocking=False)
     if not acquired:
+        RERANK_REQUESTS_TOTAL.labels(status_code="503").inc()
         raise HTTPException(status_code=503, detail="Reranker service busy — retry shortly")
+
+    start_time = time.monotonic()
+    ACTIVE_INFERENCE_REQUESTS.inc()
     try:
         inputs = reranker_tokenizer(
             req.pairs,
@@ -172,9 +244,18 @@ def rerank_pairs(req: RerankPairRequest):
                 scores = [float(logits.item())]
             else:
                 scores = logits.tolist()
+
+        duration = time.monotonic() - start_time
+        RERANK_LATENCY.observe(duration)
+        RERANK_REQUESTS_TOTAL.labels(status_code="200").inc()
+        DOCUMENTS_RERANKED_TOTAL.inc(len(req.pairs))
+
         return RerankResponse(scores=scores, model=RERANKER_MODEL_NAME)
     except Exception as e:
         logger.error(f"Reranking error: {e}")
+        RERANK_REQUESTS_TOTAL.labels(status_code="500").inc()
         raise HTTPException(status_code=500, detail="Reranking failed")
     finally:
+        ACTIVE_INFERENCE_REQUESTS.dec()
         _inference_sem.release()
+

--- a/services/embedding-reranker/requirements.txt
+++ b/services/embedding-reranker/requirements.txt
@@ -5,3 +5,5 @@ transformers>=4.30.0
 torch>=2.0.0
 pydantic>=2.0.0
 requests>=2.28.0
+prometheus-client>=0.17.0
+


### PR DESCRIPTION
### Root Cause Analysis

Prometheus on Node 4 (`10.100.97.74`) previously reported the scrape target `node4-embedding-reranker` as `DOWN` with the error:

```
received unsupported Content-Type "application/json" and no fallback_scrape_protocol specified for target
```

This occurred because Prometheus was configured with `metrics_path: /health`, which returns JSON status (`{"status": "ok"}`), and the `embedding-reranker` service did not implement a dedicated `/metrics` endpoint.

---

### Implementation Details & Added Metrics

Instead of removing the scrape target, this PR adds full production-grade Prometheus instrumentation using `prometheus-client` to the `embedding-reranker` FastAPI microservice:

1. **`tei_embedding_requests_total{status_code}` (Counter):** Tracks total embedding HTTP request counts partitioned by HTTP status code (`200`, `500`, `503`).
2. **`tei_rerank_requests_total{status_code}` (Counter):** Tracks total reranking HTTP request counts partitioned by HTTP status code (`200`, `500`, `503`).
3. **`tei_embedding_duration_seconds` (Histogram):** Measures end-to-end embedding inference latency with high-resolution histogram buckets (`0.005s` to `5.0s`).
4. **`tei_rerank_duration_seconds` (Histogram):** Measures cross-encoder reranking inference latency with high-resolution histogram buckets (`0.005s` to `5.0s`).
5. **`tei_documents_embedded_total` (Counter):** Tracks total volume of text chunks encoded by the embedding model.
6. **`tei_documents_reranked_total` (Counter):** Tracks total candidate query-passage pairs evaluated by the reranker model.
7. **`tei_active_requests` (Gauge):** Monitors real-time active inference requests currently executing.
8. **`tei_semaphore_available` (Gauge):** Tracks available capacity in the inference concurrency semaphore (`MAX_CONCURRENT_INFERENCE`).

---

### Promotional Exposition & Scrape Target Fix

- Added `GET /metrics` endpoint in [services/embedding-reranker/app/main.py](file:///Users/vedant_shah/Desktop/DAU-pwa/services/embedding-reranker/app/main.py) returning `text/plain; version=0.0.4; charset=utf-8` via `prometheus_client.generate_latest()`.
- Updated [.github/deploy/monitoring/prometheus.yml](file:///Users/vedant_shah/Desktop/DAU-pwa/.github/deploy/monitoring/prometheus.yml) scrape job `node4-embedding-reranker` from `metrics_path: /health` to `metrics_path: /metrics`.
- Added `prometheus-client>=0.17.0` to [services/embedding-reranker/requirements.txt](file:///Users/vedant_shah/Desktop/DAU-pwa/services/embedding-reranker/requirements.txt).
- Existing `/health` endpoint remains **100% unchanged** for Docker health checks.

---

### Example `/metrics` Output

```prometheus
# HELP tei_embedding_requests_total Total embedding HTTP requests handled
# TYPE tei_embedding_requests_total counter
tei_embedding_requests_total{status_code="200"} 42.0

# HELP tei_rerank_requests_total Total rerank HTTP requests handled
# TYPE tei_rerank_requests_total counter
tei_rerank_requests_total{status_code="200"} 38.0

# HELP tei_embedding_duration_seconds Embedding processing latency in seconds
# TYPE tei_embedding_duration_seconds histogram
tei_embedding_duration_seconds_bucket{le="0.05"} 40.0
tei_embedding_duration_seconds_sum 0.854

# HELP tei_documents_embedded_total Total individual text documents encoded by embedding model
# TYPE tei_documents_embedded_total counter
tei_documents_embedded_total 128.0

# HELP tei_active_requests Number of active inference requests currently running
# TYPE tei_active_requests gauge
tei_active_requests 0.0

# HELP tei_semaphore_available Available capacity in the inference concurrency semaphore
# TYPE tei_semaphore_available gauge
tei_semaphore_available 2.0
```
