### PR TITLE
fix(rag): resolve merge conflicts and integrate temporal document boosting

### DIFF
--- a/server/rag/pipeline/generation/answer_generator.py
+++ b/server/rag/pipeline/generation/answer_generator.py
@@ -271,6 +271,14 @@ Restating the positive set is not an answer to a negation question.
 - every cited id exists in `<context>`,
 - every number, name, and modal verb matches the source exactly.
 
+# STRICT ENTITY VERIFICATION
+
+When the user asks for information about a specific person (e.g., by name):
+- Verify that the retrieved documents contain that *exact* person's name.
+- Allow for minor spelling typos (e.g., 1 or 2 letters off, like "Aditya Kausik" instead of "Aditya Kaushik").
+- **DO NOT** substitute entirely different names (e.g., "Aditya Rao" is NOT "Aditya Kaushik", even though the first name matches).
+- If the documents only contain information about a different person with a similar name, you **MUST** explicitly state that no information is available for the requested person. Do not provide the other person's info.
+
 # PRESERVATION RULES
 
 Copy these from the source verbatim. Never paraphrase, round, upgrade, or soften.

--- a/server/rag/pipeline/generation/answer_generator.py
+++ b/server/rag/pipeline/generation/answer_generator.py
@@ -279,6 +279,12 @@ When the user asks for information about a specific person (e.g., by name):
 - **DO NOT** substitute entirely different names (e.g., "Aditya Rao" is NOT "Aditya Kaushik", even though the first name matches).
 - If the documents only contain information about a different person with a similar name, you **MUST** explicitly state that no information is available for the requested person. Do not provide the other person's info.
 
+# HANDLING PARTIAL INFORMATION
+
+If the user asks for a detailed list (like an academic curriculum or course sequence) but the retrieved documents only provide a high-level overview or structural outline:
+- **DO NOT** say you cannot retrieve the information or refuse to answer.
+- Provide the structural overview that is available (e.g., the categories of courses), and explicitly state that the detailed semester-wise list is not present in the current documents.
+
 # PRESERVATION RULES
 
 Copy these from the source verbatim. Never paraphrase, round, upgrade, or soften.

--- a/server/rag/pipeline/retrieval/reranker.py
+++ b/server/rag/pipeline/retrieval/reranker.py
@@ -1,10 +1,38 @@
 import os
 import math
 import torch
+import re
+from datetime import datetime
 from transformers import (
     AutoTokenizer,
     AutoModelForSequenceClassification
 )
+
+from typing import Optional
+
+def extract_latest_year(metadata: dict) -> Optional[int]:
+    """Extract the most recent year from a document's metadata."""
+    doc_year = metadata.get("document_year", "")
+    if doc_year:
+        m = re.search(r"(20[1-3]\d)", str(doc_year))
+        if m:
+            return int(m.group(1))
+
+    texts_to_search = [
+        metadata.get("title", ""),
+        metadata.get("h1", ""),
+        metadata.get("h2", ""),
+        metadata.get("h3", ""),
+        metadata.get("text", "")
+    ]
+
+    for text in texts_to_search:
+        if not text:
+            continue
+        matches = re.findall(r"\b(20[1-3]\d)(?:[-\u2013/]\d{2,4})?\b", str(text))
+        if matches:
+            return max(int(m) for m in matches)
+    return None
 
 
 class Reranker:
@@ -295,6 +323,9 @@ class Reranker:
             )
         )
 
+        explicit_rule_year = entities.get("rule_year")
+        current_year = datetime.now().year
+
         for result, cross_score in zip(
             results,
             cross_scores
@@ -442,11 +473,21 @@ class Reranker:
             section_boost = min(section_boost, 1.0)
             course_match_boost = min(course_match_boost, 1.0)
 
+            temporal_boost = 0.0
+            if not explicit_rule_year:
+                doc_year = extract_latest_year(metadata)
+                if doc_year:
+                    diff = current_year - doc_year
+                    if diff <= 0:
+                        temporal_boost = 1.0
+                    elif diff <= 5:
+                        temporal_boost = max(0.0, 1.0 - (diff * 0.2))
+
             # Fix #4: all components are now on comparable scales [0, 1].
             # course_match_boost is weighted at 0.20 (was a raw +0.35 add).
             # semester_penalty is applied to the normalised cross component.
             final_score = (
-                (0.65 * norm_cross)
+                (0.60 * norm_cross)
                 +
                 (0.15 * dense_score)
                 +
@@ -457,6 +498,8 @@ class Reranker:
                 (0.05 * section_boost)
                 +
                 (0.05 * course_match_boost)
+                +
+                (0.05 * temporal_boost)
                 +
                 # Fix #13: penalty is now a fraction of the normalised cross
                 # score so it remains meaningful even at high relevance.


### PR DESCRIPTION
### Summary of Resolved PR (meet/rag-recent-boost)

This branch resolves the merge conflict in `server/rag/pipeline/retrieval/reranker.py` between `origin/main` and `origin/meet/rag-recent-boost` (PR #266).

- **Unified Temporal & Recency Boosting:** Combines document metadata year extraction (`extract_latest_year`) with recency decay scoring into a single 0.05 weighted factor (`temporal_boost`).
- **Strict Entity Verification Rule:** Enforces strict name verification in `answer_generator.py` system prompt (allowing 1-2 letter typos but prohibiting substituting different people with matching first names).
- **Graceful Partial Information Rule:** Handles partial curriculum/structure queries by instructing the model to provide available structural overviews rather than refusing to answer.
