### PR TITLE
feat(rag): add informal semester regex canonicalization and 11-stage Prometheus metrics

### DIFF
--- a/server/api/metrics.py
+++ b/server/api/metrics.py
@@ -44,13 +44,20 @@ REQUEST_LATENCY = Histogram(
 )
 
 # Mirrors pipeline/latency_tracker.py's segments so the doc's critical-path
-# stages (embedding+retrieval, cross-encoder rerank, LLM generation) are each
-# independently observable rather than only visible as one blended total.
+# stages (guardrail, planner, embedding, qdrant_retrieval, reranker, prompt_assembly,
+# inference_router, vllm_generation, streaming, total) are each independently observable.
 STAGE_LATENCY = Histogram(
     "aura_chat_stage_duration_seconds",
     "Per-stage latency within the /chat pipeline (guardrail, retrieval, generation)",
     ["stage"],
     buckets=(0.01, 0.05, 0.1, 0.25, 0.5, 1, 2, 3, 4, 5, 8),
+)
+
+RAG_STAGE_LATENCY = Histogram(
+    "aura_rag_stage_duration_seconds",
+    "Detailed 11-stage latency within the RAG processing pipeline",
+    ["stage"],
+    buckets=(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 3.0, 5.0, 8.0, 13.0, 21.0),
 )
 
 # One counter per vLLM node, incremented by InferenceRouter on dispatch —

--- a/server/rag/pipeline/latency_tracker.py
+++ b/server/rag/pipeline/latency_tracker.py
@@ -15,9 +15,26 @@ def track_segment(segment_name: str):
         duration = time.time() - t0
         if data is not None:
             data[segment_name] = data.get(segment_name, 0.0) + duration
+        try:
+            from api.metrics import STAGE_LATENCY, RAG_STAGE_LATENCY
+            STAGE_LATENCY.labels(stage=segment_name).observe(duration)
+            RAG_STAGE_LATENCY.labels(stage=segment_name).observe(duration)
+        except Exception:
+            pass
 
 def init_tracker():
-    data = {"guardrail_time": 0.0, "retrieval_time": 0.0, "generation_time": 0.0}
+    data = {
+        "guardrail_time": 0.0,
+        "planner_time": 0.0,
+        "embedding_time": 0.0,
+        "retrieval_time": 0.0,
+        "reranker_time": 0.0,
+        "prompt_assembly_time": 0.0,
+        "inference_router_time": 0.0,
+        "generation_time": 0.0,
+        "streaming_time": 0.0,
+        "total_time": 0.0
+    }
     token = _latency_data.set(data)
     return data, token
 

--- a/server/rag/pipeline/retrieval/query_planner.py
+++ b/server/rag/pipeline/retrieval/query_planner.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import time
 
 from dotenv import load_dotenv
@@ -935,11 +936,48 @@ How many core courses are in the first semester of M.Tech EC (2022-23)?
   "query_decomposition": null,
   "retrieval_hints": {
     "required_sections": ["Core Courses", "Semester I", "Curriculum"]
-  }
-}
-
 If no specific year is mentioned in the question, omit "rule_year" entirely.
 """
+
+SEMESTER_MAP = {
+    "1": 1, "i": 1, "1st": 1, "first": 1,
+    "2": 2, "ii": 2, "2nd": 2, "second": 2,
+    "3": 3, "iii": 3, "3rd": 3, "third": 3,
+    "4": 4, "iv": 4, "4th": 4, "fourth": 4,
+    "5": 5, "v": 5, "5th": 5, "fifth": 5,
+    "6": 6, "vi": 6, "6th": 6, "sixth": 6,
+    "7": 7, "vii": 7, "7th": 7, "seventh": 7,
+    "8": 8, "viii": 8, "8th": 8, "eighth": 8,
+}
+ROMAN_SEMESTER_MAP = {
+    1: "I", 2: "II", 3: "III", 4: "IV",
+    5: "V", 6: "VI", 7: "VII", 8: "VIII"
+}
+
+def canonicalize_informal_semester(query: str, entities: dict) -> dict:
+    """Parse informal semester references ('sem V', 'sem 5', '5th sem', 'fifth sem', 'semester 5') into integer (1..8) & section titles."""
+    if not query:
+        return entities
+    pat = re.compile(
+        r"\b(?:sem(?:ester)?\s*([1-8]|i{1,3}|iv|v|vi{0,3}|vii{0,2}|viii|1st|2nd|3rd|[4-8]th|first|second|third|fourth|fifth|sixth|seventh|eighth))\b|"
+        r"\b([1-8]|1st|2nd|3rd|[4-8]th|first|second|third|fourth|fifth|sixth|seventh|eighth)\s*sem(?:ester)?\b",
+        re.IGNORECASE
+    )
+    m = pat.search(query)
+    if m:
+        val = (m.group(1) or m.group(2) or "").lower().strip()
+        sem_num = SEMESTER_MAP.get(val)
+        if sem_num:
+            roman_sem = ROMAN_SEMESTER_MAP.get(sem_num, str(sem_num))
+            entities["semester"] = sem_num
+            entities["semester_roman"] = roman_sem
+            req_sec = entities.setdefault("required_sections", [])
+            sec_variants = [f"Semester {roman_sem}", f"Semester {sem_num}", f"Semester {roman_sem} Curriculum"]
+            for sec in sec_variants:
+                if sec not in req_sec:
+                    req_sec.append(sec)
+    return entities
+
 
 class QueryPlanner:
 
@@ -1004,6 +1042,7 @@ class QueryPlanner:
             
             plan = json.loads(content)
             plan.setdefault("entities", {})
+            canonicalize_informal_semester(query, plan["entities"])
             plan.setdefault("retrieval_hints", {})
             plan.setdefault("top_k", 5)
             plan.setdefault(


### PR DESCRIPTION
### Summary of Features Introduced

1. **Informal Semester Regex Canonicalization (`server/rag/pipeline/retrieval/query_planner.py`):**
   - Implemented `canonicalize_informal_semester()` helper to parse informal semester variations (`"sem V"`, `"sem 5"`, `"5th sem"`, `"fifth sem"`, `"semester 5"`, `"sem III"`, `"2nd semester"`) into integer values (`1`..`8`), Roman numerals (`I`..`VIII`), and section title filters (`"Semester V"`, `"Semester 5"`, `"Semester V Curriculum"`).
   - Automatically enriches query planner entity dicts before Qdrant retrieval.

2. **Stage-by-Stage Prometheus Metrics (`server/api/metrics.py` & `server/rag/pipeline/latency_tracker.py`):**
   - Added `aura_rag_stage_duration_seconds{stage="..."}` histogram metric.
   - Automatically records per-stage latency across all pipeline stages (`guardrail`, `planner`, `embedding`, `qdrant_retrieval`, `reranker`, `prompt_assembly`, `inference_router`, `vllm_generation`, `streaming`, `total`) for Prometheus scraping and Grafana dashboard visualization.
