### PR TITLE
Add club committee contact data

### DIFF
--- a/data/student_faculty/sbg_club_committee_information_2026_27_responses.md
+++ b/data/student_faculty/sbg_club_committee_information_2026_27_responses.md
@@ -1,0 +1,521 @@
+---
+title: "Club Committee Information 2026-27 Responses"
+url: "#"
+category: "SBG & Clubs - Clubs And Committees"
+scraped_by: "Om Patel"
+scraped_date: "2026-07-31"
+team: "SBG Data"
+source_type: "XLSX"
+original_name: "Club_Committee Information 2026-27 (Responses).xlsx"
+authorization: ["student", "faculty"]
+---
+
+# Club Committee Information 2026-27 Responses
+
+## Source Summary
+
+- **Source Sheet:** Form Responses 1
+- **Total Entries:** 33
+- **Data Coverage:** timestamp, email address, email ID, club/committee name, convener details, deputy convener details, and faculty mentor.
+
+## Club and Committee Contact Table
+
+| Timestamp | Email Address | Email ID | Club/Committee Name | Convener Name | Convener Student ID | Convener Mobile Number | Dy. Convener Name | Dy. Convener Student ID | Dy. Convener Mobile Number | Faculty Mentor Name |
+|---|---|---|---|---|---|---|---|---|---|---|
+| 2026-04-21 07:05:43.917000 | research_club@dau.ac.in | research_club@dau.ac.in | Research Club | Devdutt Dinesh | 202403007 | 7012438105 | Praneel Sharma | 202401166 | 9925195623 | Prof. Yash Vasavada |
+| 2026-04-21 13:42:55.603000 | heritage@dau.ac.in | heritage@dau.ac.in | Heritage Club | Virat Shrimali | 202303061 | 8799128251 | Tirth Kansagra | 202303055 | 8849348088 | Prof. Nandini Banerjee |
+| 2026-04-21 14:43:42.386000 | dsc@dau.ac.in | dsc@dau.ac.in | Google Developer Groups | Aditya Vaish | 202401401 | 7248463142 | Zalak Thakkar | 202401482 | 9157891418 | Prof. Ankush Chander |
+| 2026-04-21 15:28:19.253000 | film_club@dau.ac.in | film_club@dau.ac.in | Film Club | Vatsal Mori | 202401436 | 8980498027 | Shrey Patel | 202401449 | 7069963947 | Jenson Joseph |
+| 2026-04-21 15:43:59.667000 | cubing_club@dau.ac.in | cubing_club@dau.ac.in | Cubing Club | Vatsal Mori | 202401436 | 8980498027 | Yashvi Pachani | 202403062 | 8128074477 | V Sunitha |
+| 2026-04-22 11:19:14.826000 | quizzing@dau.ac.in | quizzing@dau.ac.in | Headrush | Prithviraj Nalvaya | 202401169 | 6358849146 | Nikhil Gupta | 202404023 | 9149083243 | Rachit Chhaya |
+| 2026-04-22 17:03:18.908000 | sambhav@dau.ac.in | sambhav@dau.ac.in | SAMBHAV | JOGADIYA DHARA R. | 202301195 | 8140768276 | TANDEL DHRUVINEE D. | 202301203 | 7383135327 | PROF. YASH VASAVADA |
+| 2026-04-23 16:55:14.469000 | music_club@dau.ac.in | music_club@dau.ac.in | The Music Club | Rishabh Jalu | 202301265 | 9316179959 | Pal Kaneria | 202301021 | 87990 06221 | Prof. P.S.Kalyan Sasidhar |
+| 2026-04-29 21:39:20.873000 | muse@dau.ac.in | muse@dau.ac.in | Muse - The Design Club | Diya Bhuva | 202401410 | 9978033924 | Yashvi Patel | 202403035 | 7874455893 | Anupam Rana Sir |
+| 2026-07-16 00:38:57.848000 | business_club@dau.ac.in | Business_club@dau.ac.in | Business Club | Satvik Parihar | 202401189 | 6261695658 | Malhar Jani | 202503014 | 8160372284 | Dr Pankaj Kumar |
+| 2026-04-29 21:43:42.277000 | pressclub@dau.ac.in | pressclub@dau.ac.in | Press Club | Devdutt Dinesh | 202403007 | +91 70124 38105 | Prakriti Pandey | 202401164 | +91 8368598565 | Prof Amishal Modi |
+| 2026-04-29 21:44:03.178000 | khelaiya_club@dau.ac.in | khelaiya_club@dau.ac.in | Khelaiya Club | Prince Kapadiya | 202403021 | 9913037628 | Divya Patel | 202401446 | 9023666261 | Prof. Sreeja Rajendran |
+| 2026-04-29 21:46:26.050000 | chess_club@dau.ac.in | chess_club@dau.ac.in | Chess Club | Vishwam Thaker | 202401244 | 8200738823 | Tirth Patel | 202401227 | 9687532568 | Prof. Rahul Muthu |
+| 2026-04-29 21:48:30.865000 | pmmc@dau.ac.in | pmmc@dau.ac.in | Photography & Movie Making Club | Yash Ravat | 202401182 | 8799169690 | Khanjan Shah | 202401092 | 9409133900 | Prof. Mukesh Tiwari |
+| 2026-04-29 21:54:24.486000 | sbg_academics@dau.ac.in | sbg_academics@dau.ac.in | Academic Committee | Hari Sharma | 202401195 | 9106854849 | Pranamya Sanghvi | 202401165 | 7284902836 | Prof. Bhaskar Chaudhary |
+| 2026-04-29 22:10:33.831000 | ehc@dau.ac.in | ehc@dau.ac.in | Electronics Hobby Club (EHC) | Shyam Bhuva | 202401034 | 9265876690 | Vyom Patel | 202401245 | 8487847235 | Prof. Sujay Kadam |
+| 2026-07-07 11:06:56.454000 | sports@dau.ac.in | sports@daiict.ac.in | Sports Committee | Neeti Gunsai | 202401423 | 6355770669 | Kush Patel | 202401448 | 87801 32145 | Prof. Rahul Muthu |
+| 2026-04-29 22:20:56.768000 | programming-club@dau.ac.in | programming-club@dau.ac.in | Programming Club | Mahek Kanani | 202403019 | 96015 94723 | Raj Patel | 202401152 | 94266 25583 | Prof. PM jat |
+| 2026-04-29 22:24:35.863000 | hmc@dau.ac.in | hmc@dau.ac.in | Hostel management committee | Gauswami Sumit | 202401055 | 9664515557 | Manali Malani | 202401111 | 8200464842 | Proff.Madhukant Sharma |
+| 2026-04-29 23:03:45.561000 | ieee@dau.ac.in | ieee@dau.ac.in | IEEE SB DAIICT | Jeet Modi | 202301412 | 7878471499 | Parthiv Bhesaniya | 202303037 | 8758791646 | Pankaj Kumar |
+| 2026-07-03 14:45:21.060000 | spc@dau.ac.in | spc@dau.ac.in | Student Placement Cell | Jevik Rakholiya | 202301276 | +91 90239 47519 | Chaitanya Vats | 202301419 | +91 7046200969 | Prof. Yash Agarwal and Prof. Saurabh Tiwari |
+| 2026-04-30 14:10:30.138000 | tech_support@dau.ac.in | tech_support@dau.ac.in | Tech support comittee | Devarshi Dave | 202404007 | 8393017959 | Hemin Siddhapura | 202404055 | 9313196623 | Dr. Yash Agarwal |
+| 2026-04-30 01:19:06.187000 | theatres@dau.ac.in | theatres@dau.ac.in | Khoj Theatres (DTG) | Pooja Makwana | 202404020 | 8347106261 | Neel Shah | 202501028 | 9157317015 | Shefali Jha |
+| 2026-04-30 01:26:39.799000 | debate_club@dau.ac.in | debate_club@dau.ac.in | The Debating Society | Prachita Maiti | 202403036 | 8799308041 | Madhavan Dinesh | 202403026 | 6353910047 | Purbhasha Das |
+| 2026-04-30 14:09:38.545000 | radio@dau.ac.in | radio@dau.ac.in | Radio Club | Prayag Kachhia | 202401168 | 9983690170 | Yagnik Patel | 202401160 | 9662003023 | Amishal Modi |
+| 2026-05-23 15:17:31.648000 | ai_club@dau.ac.in | ai_club@dau.ac.in | AI Club | Vedant Shah | 202401475 | 9023095963 | Aaditya Kaushik | 202401001 | 85294 51266 | Arpit Rana |
+| 2026-05-21 17:33:09.081000 | cins_club@dau.ac.in | cins_club@dau.ac.in | Cyber Information and Network Security club | Krit Shah | 202503021 | 7471176443 | Tanvi Dayani | 202501154 | 8347051362 | Abhishek Jindal |
+| 2026-04-30 14:49:19.170000 | microsoftclub@dau.ac.in | microsoftclub@daiict.ac.in | Microsoft Student Technical Club | Mohammadjunaid S. Kureshi | 202401102 | 8401317679 | Tirth Patel | 202401157 | 7984574445 | Pm Jat |
+| 2026-07-03 16:27:31.225000 | synapse@dau.ac.in | synapse@dau.ac.in | Synapse Committee | Om Santoki | 202301019 | 9328956812 | Sujal Mohapatra | 202301428 | 8319035018 | Prof. Rahul Muthu |
+| 2026-05-28 18:25:11.650000 | danceclub@dau.ac.in | danceclub@dau.ac.in | DADC | Vedant Sanjaykumar Shah | 202401475 | 9023095963 | Diya Pitroda | 202404009 | 7622030777 | Sreeja Rajendran |
+| 2026-06-03 17:47:38.489000 | readers_society@dau.ac.in | readers_society@dau.ac.in | Readers' Society | Affan Riyaz Shaikh | 202401009 | +91 9137838656 | Prithviraj Nalvaya | 202401169 | +91 63588 49146 | Amishal Modi |
+| 2026-07-03 14:46:36.552000 | cmc@dau.ac.in | cmc@dau.ac.in | Cafeteria Management Committee | Prince Sojitra | 202301126 | 8780377541 | Varshil Shah | 202401194 | 9601991253 | Prof. Aditya Tatu |
+| 2026-07-07 10:43:00.144000 | cultural@dau.ac.in | cultural@dau.ac.in | Cultural Committee | Meet Jain | 202301073 | 9875212837 | Het Ladani | 202301102 | 9426939547 | Prof. Rahul Muthu |
+
+## Atomic Club and Committee Records
+
+### Research Club
+
+- **Timestamp:** 2026-04-21 07:05:43.917000
+- **Email Address:** research_club@dau.ac.in
+- **Email ID:** research_club@dau.ac.in
+- **Club/Committee Name:** Research Club
+- **Convener Name:** Devdutt Dinesh
+- **Convener Student ID:** 202403007
+- **Convener Mobile Number:** 7012438105
+- **Dy. Convener Name:** Praneel Sharma
+- **Dy. Convener Student ID:** 202401166
+- **Dy. Convener Mobile Number:** 9925195623
+- **Faculty Mentor Name:** Prof. Yash Vasavada
+
+### Heritage Club
+
+- **Timestamp:** 2026-04-21 13:42:55.603000
+- **Email Address:** heritage@dau.ac.in
+- **Email ID:** heritage@dau.ac.in
+- **Club/Committee Name:** Heritage Club
+- **Convener Name:** Virat Shrimali
+- **Convener Student ID:** 202303061
+- **Convener Mobile Number:** 8799128251
+- **Dy. Convener Name:** Tirth Kansagra
+- **Dy. Convener Student ID:** 202303055
+- **Dy. Convener Mobile Number:** 8849348088
+- **Faculty Mentor Name:** Prof. Nandini Banerjee
+
+### Google Developer Groups
+
+- **Timestamp:** 2026-04-21 14:43:42.386000
+- **Email Address:** dsc@dau.ac.in
+- **Email ID:** dsc@dau.ac.in
+- **Club/Committee Name:** Google Developer Groups
+- **Convener Name:** Aditya Vaish
+- **Convener Student ID:** 202401401
+- **Convener Mobile Number:** 7248463142
+- **Dy. Convener Name:** Zalak Thakkar
+- **Dy. Convener Student ID:** 202401482
+- **Dy. Convener Mobile Number:** 9157891418
+- **Faculty Mentor Name:** Prof. Ankush Chander
+
+### Film Club
+
+- **Timestamp:** 2026-04-21 15:28:19.253000
+- **Email Address:** film_club@dau.ac.in
+- **Email ID:** film_club@dau.ac.in
+- **Club/Committee Name:** Film Club
+- **Convener Name:** Vatsal Mori
+- **Convener Student ID:** 202401436
+- **Convener Mobile Number:** 8980498027
+- **Dy. Convener Name:** Shrey Patel
+- **Dy. Convener Student ID:** 202401449
+- **Dy. Convener Mobile Number:** 7069963947
+- **Faculty Mentor Name:** Jenson Joseph
+
+### Cubing Club
+
+- **Timestamp:** 2026-04-21 15:43:59.667000
+- **Email Address:** cubing_club@dau.ac.in
+- **Email ID:** cubing_club@dau.ac.in
+- **Club/Committee Name:** Cubing Club
+- **Convener Name:** Vatsal Mori
+- **Convener Student ID:** 202401436
+- **Convener Mobile Number:** 8980498027
+- **Dy. Convener Name:** Yashvi Pachani
+- **Dy. Convener Student ID:** 202403062
+- **Dy. Convener Mobile Number:** 8128074477
+- **Faculty Mentor Name:** V Sunitha
+
+### Headrush
+
+- **Timestamp:** 2026-04-22 11:19:14.826000
+- **Email Address:** quizzing@dau.ac.in
+- **Email ID:** quizzing@dau.ac.in
+- **Club/Committee Name:** Headrush
+- **Convener Name:** Prithviraj Nalvaya
+- **Convener Student ID:** 202401169
+- **Convener Mobile Number:** 6358849146
+- **Dy. Convener Name:** Nikhil Gupta
+- **Dy. Convener Student ID:** 202404023
+- **Dy. Convener Mobile Number:** 9149083243
+- **Faculty Mentor Name:** Rachit Chhaya
+
+### SAMBHAV
+
+- **Timestamp:** 2026-04-22 17:03:18.908000
+- **Email Address:** sambhav@dau.ac.in
+- **Email ID:** sambhav@dau.ac.in
+- **Club/Committee Name:** SAMBHAV
+- **Convener Name:** JOGADIYA DHARA R.
+- **Convener Student ID:** 202301195
+- **Convener Mobile Number:** 8140768276
+- **Dy. Convener Name:** TANDEL DHRUVINEE D.
+- **Dy. Convener Student ID:** 202301203
+- **Dy. Convener Mobile Number:** 7383135327
+- **Faculty Mentor Name:** PROF. YASH VASAVADA
+
+### The Music Club
+
+- **Timestamp:** 2026-04-23 16:55:14.469000
+- **Email Address:** music_club@dau.ac.in
+- **Email ID:** music_club@dau.ac.in
+- **Club/Committee Name:** The Music Club
+- **Convener Name:** Rishabh Jalu
+- **Convener Student ID:** 202301265
+- **Convener Mobile Number:** 9316179959
+- **Dy. Convener Name:** Pal Kaneria
+- **Dy. Convener Student ID:** 202301021
+- **Dy. Convener Mobile Number:** 87990 06221
+- **Faculty Mentor Name:** Prof. P.S.Kalyan Sasidhar
+
+### Muse - The Design Club
+
+- **Timestamp:** 2026-04-29 21:39:20.873000
+- **Email Address:** muse@dau.ac.in
+- **Email ID:** muse@dau.ac.in
+- **Club/Committee Name:** Muse - The Design Club
+- **Convener Name:** Diya Bhuva
+- **Convener Student ID:** 202401410
+- **Convener Mobile Number:** 9978033924
+- **Dy. Convener Name:** Yashvi Patel
+- **Dy. Convener Student ID:** 202403035
+- **Dy. Convener Mobile Number:** 7874455893
+- **Faculty Mentor Name:** Anupam Rana Sir
+
+### Business Club
+
+- **Timestamp:** 2026-07-16 00:38:57.848000
+- **Email Address:** business_club@dau.ac.in
+- **Email ID:** Business_club@dau.ac.in
+- **Club/Committee Name:** Business Club
+- **Convener Name:** Satvik Parihar
+- **Convener Student ID:** 202401189
+- **Convener Mobile Number:** 6261695658
+- **Dy. Convener Name:** Malhar Jani
+- **Dy. Convener Student ID:** 202503014
+- **Dy. Convener Mobile Number:** 8160372284
+- **Faculty Mentor Name:** Dr Pankaj Kumar
+
+### Press Club
+
+- **Timestamp:** 2026-04-29 21:43:42.277000
+- **Email Address:** pressclub@dau.ac.in
+- **Email ID:** pressclub@dau.ac.in
+- **Club/Committee Name:** Press Club
+- **Convener Name:** Devdutt Dinesh
+- **Convener Student ID:** 202403007
+- **Convener Mobile Number:** +91 70124 38105
+- **Dy. Convener Name:** Prakriti Pandey
+- **Dy. Convener Student ID:** 202401164
+- **Dy. Convener Mobile Number:** +91 8368598565
+- **Faculty Mentor Name:** Prof Amishal Modi
+
+### Khelaiya Club
+
+- **Timestamp:** 2026-04-29 21:44:03.178000
+- **Email Address:** khelaiya_club@dau.ac.in
+- **Email ID:** khelaiya_club@dau.ac.in
+- **Club/Committee Name:** Khelaiya Club
+- **Convener Name:** Prince Kapadiya
+- **Convener Student ID:** 202403021
+- **Convener Mobile Number:** 9913037628
+- **Dy. Convener Name:** Divya Patel
+- **Dy. Convener Student ID:** 202401446
+- **Dy. Convener Mobile Number:** 9023666261
+- **Faculty Mentor Name:** Prof. Sreeja Rajendran
+
+### Chess Club
+
+- **Timestamp:** 2026-04-29 21:46:26.050000
+- **Email Address:** chess_club@dau.ac.in
+- **Email ID:** chess_club@dau.ac.in
+- **Club/Committee Name:** Chess Club
+- **Convener Name:** Vishwam Thaker
+- **Convener Student ID:** 202401244
+- **Convener Mobile Number:** 8200738823
+- **Dy. Convener Name:** Tirth Patel
+- **Dy. Convener Student ID:** 202401227
+- **Dy. Convener Mobile Number:** 9687532568
+- **Faculty Mentor Name:** Prof. Rahul Muthu
+
+### Photography & Movie Making Club
+
+- **Timestamp:** 2026-04-29 21:48:30.865000
+- **Email Address:** pmmc@dau.ac.in
+- **Email ID:** pmmc@dau.ac.in
+- **Club/Committee Name:** Photography & Movie Making Club
+- **Convener Name:** Yash Ravat
+- **Convener Student ID:** 202401182
+- **Convener Mobile Number:** 8799169690
+- **Dy. Convener Name:** Khanjan Shah
+- **Dy. Convener Student ID:** 202401092
+- **Dy. Convener Mobile Number:** 9409133900
+- **Faculty Mentor Name:** Prof. Mukesh Tiwari
+
+### Academic Committee
+
+- **Timestamp:** 2026-04-29 21:54:24.486000
+- **Email Address:** sbg_academics@dau.ac.in
+- **Email ID:** sbg_academics@dau.ac.in
+- **Club/Committee Name:** Academic Committee
+- **Convener Name:** Hari Sharma
+- **Convener Student ID:** 202401195
+- **Convener Mobile Number:** 9106854849
+- **Dy. Convener Name:** Pranamya Sanghvi
+- **Dy. Convener Student ID:** 202401165
+- **Dy. Convener Mobile Number:** 7284902836
+- **Faculty Mentor Name:** Prof. Bhaskar Chaudhary
+
+### Electronics Hobby Club (EHC)
+
+- **Timestamp:** 2026-04-29 22:10:33.831000
+- **Email Address:** ehc@dau.ac.in
+- **Email ID:** ehc@dau.ac.in
+- **Club/Committee Name:** Electronics Hobby Club (EHC)
+- **Convener Name:** Shyam Bhuva
+- **Convener Student ID:** 202401034
+- **Convener Mobile Number:** 9265876690
+- **Dy. Convener Name:** Vyom Patel
+- **Dy. Convener Student ID:** 202401245
+- **Dy. Convener Mobile Number:** 8487847235
+- **Faculty Mentor Name:** Prof. Sujay Kadam
+
+### Sports Committee
+
+- **Timestamp:** 2026-07-07 11:06:56.454000
+- **Email Address:** sports@dau.ac.in
+- **Email ID:** sports@daiict.ac.in
+- **Club/Committee Name:** Sports Committee
+- **Convener Name:** Neeti Gunsai
+- **Convener Student ID:** 202401423
+- **Convener Mobile Number:** 6355770669
+- **Dy. Convener Name:** Kush Patel
+- **Dy. Convener Student ID:** 202401448
+- **Dy. Convener Mobile Number:** 87801 32145
+- **Faculty Mentor Name:** Prof. Rahul Muthu
+
+### Programming Club
+
+- **Timestamp:** 2026-04-29 22:20:56.768000
+- **Email Address:** programming-club@dau.ac.in
+- **Email ID:** programming-club@dau.ac.in
+- **Club/Committee Name:** Programming Club
+- **Convener Name:** Mahek Kanani
+- **Convener Student ID:** 202403019
+- **Convener Mobile Number:** 96015 94723
+- **Dy. Convener Name:** Raj Patel
+- **Dy. Convener Student ID:** 202401152
+- **Dy. Convener Mobile Number:** 94266 25583
+- **Faculty Mentor Name:** Prof. PM jat
+
+### Hostel management committee
+
+- **Timestamp:** 2026-04-29 22:24:35.863000
+- **Email Address:** hmc@dau.ac.in
+- **Email ID:** hmc@dau.ac.in
+- **Club/Committee Name:** Hostel management committee
+- **Convener Name:** Gauswami Sumit
+- **Convener Student ID:** 202401055
+- **Convener Mobile Number:** 9664515557
+- **Dy. Convener Name:** Manali Malani
+- **Dy. Convener Student ID:** 202401111
+- **Dy. Convener Mobile Number:** 8200464842
+- **Faculty Mentor Name:** Proff.Madhukant Sharma
+
+### IEEE SB DAIICT
+
+- **Timestamp:** 2026-04-29 23:03:45.561000
+- **Email Address:** ieee@dau.ac.in
+- **Email ID:** ieee@dau.ac.in
+- **Club/Committee Name:** IEEE SB DAIICT
+- **Convener Name:** Jeet Modi
+- **Convener Student ID:** 202301412
+- **Convener Mobile Number:** 7878471499
+- **Dy. Convener Name:** Parthiv Bhesaniya
+- **Dy. Convener Student ID:** 202303037
+- **Dy. Convener Mobile Number:** 8758791646
+- **Faculty Mentor Name:** Pankaj Kumar
+
+### Student Placement Cell
+
+- **Timestamp:** 2026-07-03 14:45:21.060000
+- **Email Address:** spc@dau.ac.in
+- **Email ID:** spc@dau.ac.in
+- **Club/Committee Name:** Student Placement Cell
+- **Convener Name:** Jevik Rakholiya
+- **Convener Student ID:** 202301276
+- **Convener Mobile Number:** +91 90239 47519
+- **Dy. Convener Name:** Chaitanya Vats
+- **Dy. Convener Student ID:** 202301419
+- **Dy. Convener Mobile Number:** +91 7046200969
+- **Faculty Mentor Name:** Prof. Yash Agarwal and Prof. Saurabh Tiwari
+
+### Tech support comittee
+
+- **Timestamp:** 2026-04-30 14:10:30.138000
+- **Email Address:** tech_support@dau.ac.in
+- **Email ID:** tech_support@dau.ac.in
+- **Club/Committee Name:** Tech support comittee
+- **Convener Name:** Devarshi Dave
+- **Convener Student ID:** 202404007
+- **Convener Mobile Number:** 8393017959
+- **Dy. Convener Name:** Hemin Siddhapura
+- **Dy. Convener Student ID:** 202404055
+- **Dy. Convener Mobile Number:** 9313196623
+- **Faculty Mentor Name:** Dr. Yash Agarwal
+
+### Khoj Theatres (DTG)
+
+- **Timestamp:** 2026-04-30 01:19:06.187000
+- **Email Address:** theatres@dau.ac.in
+- **Email ID:** theatres@dau.ac.in
+- **Club/Committee Name:** Khoj Theatres (DTG)
+- **Convener Name:** Pooja Makwana
+- **Convener Student ID:** 202404020
+- **Convener Mobile Number:** 8347106261
+- **Dy. Convener Name:** Neel Shah
+- **Dy. Convener Student ID:** 202501028
+- **Dy. Convener Mobile Number:** 9157317015
+- **Faculty Mentor Name:** Shefali Jha
+
+### The Debating Society
+
+- **Timestamp:** 2026-04-30 01:26:39.799000
+- **Email Address:** debate_club@dau.ac.in
+- **Email ID:** debate_club@dau.ac.in
+- **Club/Committee Name:** The Debating Society
+- **Convener Name:** Prachita Maiti
+- **Convener Student ID:** 202403036
+- **Convener Mobile Number:** 8799308041
+- **Dy. Convener Name:** Madhavan Dinesh
+- **Dy. Convener Student ID:** 202403026
+- **Dy. Convener Mobile Number:** 6353910047
+- **Faculty Mentor Name:** Purbhasha Das
+
+### Radio Club
+
+- **Timestamp:** 2026-04-30 14:09:38.545000
+- **Email Address:** radio@dau.ac.in
+- **Email ID:** radio@dau.ac.in
+- **Club/Committee Name:** Radio Club
+- **Convener Name:** Prayag Kachhia
+- **Convener Student ID:** 202401168
+- **Convener Mobile Number:** 9983690170
+- **Dy. Convener Name:** Yagnik Patel
+- **Dy. Convener Student ID:** 202401160
+- **Dy. Convener Mobile Number:** 9662003023
+- **Faculty Mentor Name:** Amishal Modi
+
+### AI Club
+
+- **Timestamp:** 2026-05-23 15:17:31.648000
+- **Email Address:** ai_club@dau.ac.in
+- **Email ID:** ai_club@dau.ac.in
+- **Club/Committee Name:** AI Club
+- **Convener Name:** Vedant Shah
+- **Convener Student ID:** 202401475
+- **Convener Mobile Number:** 9023095963
+- **Dy. Convener Name:** Aaditya Kaushik
+- **Dy. Convener Student ID:** 202401001
+- **Dy. Convener Mobile Number:** 85294 51266
+- **Faculty Mentor Name:** Arpit Rana
+
+### Cyber Information and Network Security club
+
+- **Timestamp:** 2026-05-21 17:33:09.081000
+- **Email Address:** cins_club@dau.ac.in
+- **Email ID:** cins_club@dau.ac.in
+- **Club/Committee Name:** Cyber Information and Network Security club
+- **Convener Name:** Krit Shah
+- **Convener Student ID:** 202503021
+- **Convener Mobile Number:** 7471176443
+- **Dy. Convener Name:** Tanvi Dayani
+- **Dy. Convener Student ID:** 202501154
+- **Dy. Convener Mobile Number:** 8347051362
+- **Faculty Mentor Name:** Abhishek Jindal
+
+### Microsoft Student Technical Club
+
+- **Timestamp:** 2026-04-30 14:49:19.170000
+- **Email Address:** microsoftclub@dau.ac.in
+- **Email ID:** microsoftclub@daiict.ac.in
+- **Club/Committee Name:** Microsoft Student Technical Club
+- **Convener Name:** Mohammadjunaid S. Kureshi
+- **Convener Student ID:** 202401102
+- **Convener Mobile Number:** 8401317679
+- **Dy. Convener Name:** Tirth Patel
+- **Dy. Convener Student ID:** 202401157
+- **Dy. Convener Mobile Number:** 7984574445
+- **Faculty Mentor Name:** Pm Jat
+
+### Synapse Committee
+
+- **Timestamp:** 2026-07-03 16:27:31.225000
+- **Email Address:** synapse@dau.ac.in
+- **Email ID:** synapse@dau.ac.in
+- **Club/Committee Name:** Synapse Committee
+- **Convener Name:** Om Santoki
+- **Convener Student ID:** 202301019
+- **Convener Mobile Number:** 9328956812
+- **Dy. Convener Name:** Sujal Mohapatra
+- **Dy. Convener Student ID:** 202301428
+- **Dy. Convener Mobile Number:** 8319035018
+- **Faculty Mentor Name:** Prof. Rahul Muthu
+
+### DADC
+
+- **Timestamp:** 2026-05-28 18:25:11.650000
+- **Email Address:** danceclub@dau.ac.in
+- **Email ID:** danceclub@dau.ac.in
+- **Club/Committee Name:** DADC
+- **Convener Name:** Vedant Sanjaykumar Shah
+- **Convener Student ID:** 202401475
+- **Convener Mobile Number:** 9023095963
+- **Dy. Convener Name:** Diya Pitroda
+- **Dy. Convener Student ID:** 202404009
+- **Dy. Convener Mobile Number:** 7622030777
+- **Faculty Mentor Name:** Sreeja Rajendran
+
+### Readers' Society
+
+- **Timestamp:** 2026-06-03 17:47:38.489000
+- **Email Address:** readers_society@dau.ac.in
+- **Email ID:** readers_society@dau.ac.in
+- **Club/Committee Name:** Readers' Society
+- **Convener Name:** Affan Riyaz Shaikh
+- **Convener Student ID:** 202401009
+- **Convener Mobile Number:** +91 9137838656
+- **Dy. Convener Name:** Prithviraj Nalvaya
+- **Dy. Convener Student ID:** 202401169
+- **Dy. Convener Mobile Number:** +91 63588 49146
+- **Faculty Mentor Name:** Amishal Modi
+
+### Cafeteria Management Committee
+
+- **Timestamp:** 2026-07-03 14:46:36.552000
+- **Email Address:** cmc@dau.ac.in
+- **Email ID:** cmc@dau.ac.in
+- **Club/Committee Name:** Cafeteria Management Committee
+- **Convener Name:** Prince Sojitra
+- **Convener Student ID:** 202301126
+- **Convener Mobile Number:** 8780377541
+- **Dy. Convener Name:** Varshil Shah
+- **Dy. Convener Student ID:** 202401194
+- **Dy. Convener Mobile Number:** 9601991253
+- **Faculty Mentor Name:** Prof. Aditya Tatu
+
+### Cultural Committee
+
+- **Timestamp:** 2026-07-07 10:43:00.144000
+- **Email Address:** cultural@dau.ac.in
+- **Email ID:** cultural@dau.ac.in
+- **Club/Committee Name:** Cultural Committee
+- **Convener Name:** Meet Jain
+- **Convener Student ID:** 202301073
+- **Convener Mobile Number:** 9875212837
+- **Dy. Convener Name:** Het Ladani
+- **Dy. Convener Student ID:** 202301102
+- **Dy. Convener Mobile Number:** 9426939547
+- **Faculty Mentor Name:** Prof. Rahul Muthu


### PR DESCRIPTION
## Summary

- Add RAG-ready 2026-27 club and committee contact data under `data/student_faculty`
- Preserve all submitted spreadsheet fields in a Markdown table
- Include atomic per-club/per-committee records for retrieval
- Exclude Election Commission from the final list

## Validation

- Verified 33 table rows
- Verified 33 atomic records
- Confirmed `authorization: ["student", "faculty"]` frontmatter is present
- Confirmed Election Commission is not present in the generated data file
