### PR TITLE
fix(rag): resolve multi-turn continuation queries and inject chat history into LLM messages payload

### DIFF
--- a/server/rag/pipeline/generation/answer_generator.py
+++ b/server/rag/pipeline/generation/answer_generator.py
@@ -563,29 +563,28 @@ Retrieved Documents
                 and any(lang in question_lower for lang in PROG_LANG_INDICATORS)
             ) or "palindrome" in question_lower
 
+            # Assemble multi-turn conversation messages for vLLM
+            messages_payload = [{"role": "system", "content": effective_system_prompt}]
+            if history:
+                for turn in history[-6:]:
+                    r = turn.get("role")
+                    c = turn.get("content")
+                    if r in ("user", "assistant") and c:
+                        messages_payload.append({"role": r, "content": c})
+            messages_payload.append({"role": "user", "content": prompt})
+
             if on_delta is not None and not is_code_request:
                 return self._generate_streaming(
-                    effective_system_prompt, prompt, on_delta
+                    effective_system_prompt, prompt, on_delta, history=history
                 )
 
             def _execute_generate(client):
                 return client.chat.completions.create(
                     model=self.model,
-
                     temperature=0.2,
                     top_p=0.9,
                     max_tokens=_MAX_ANSWER_TOKENS,
-
-                    messages=[
-                        {
-                            "role": "system",
-                            "content": effective_system_prompt
-                        },
-                        {
-                            "role": "user",
-                            "content": prompt
-                        }
-                    ],
+                    messages=messages_payload,
                     extra_body=InferenceRouter.answer_extra_body(),
                 )
 
@@ -605,8 +604,6 @@ Retrieved Documents
 
             if is_code_request:
                 answer_lower = answer.lower()
-                # Fix AG2: regex was double-escaped (\\b → \b literal, never matches).
-                # Correct to single-escape so word-boundary and digit patterns work.
                 is_grounded = (
                     bool(re.search(r"\bdau\b", answer_lower))
                     or "dhirubhai ambani" in answer_lower
@@ -624,33 +621,23 @@ Retrieved Documents
             import traceback; traceback.print_exc()
             return "Sorry, I encountered an error while generating a response."
 
-    def _generate_streaming(self, system_prompt, user_prompt, on_delta):
-        # Token-by-token path: sanitises deltas on the fly (think blocks and
-        # inline citations never reach the client) and returns EXACTLY the
-        # concatenation of emitted deltas, so callers can rely on
-        # streamed-content == returned answer. Stream-creation failures fail
-        # over across the vLLM pool via InferenceRouter.call_with_rotation like
-        # the buffered path; a mid-stream provider failure after first emission
-        # surfaces as a truncated answer (the client keeps what it already
-        # received) because rotation can't replay an already-emitted stream.
+    def _generate_streaming(self, system_prompt, user_prompt, on_delta, history=None):
+        stream_messages = [{"role": "system", "content": system_prompt}]
+        if history:
+            for turn in history[-6:]:
+                r = turn.get("role")
+                c = turn.get("content")
+                if r in ("user", "assistant") and c:
+                    stream_messages.append({"role": r, "content": c})
+        stream_messages.append({"role": "user", "content": user_prompt})
+
         def _execute_generate_stream(client):
             return client.chat.completions.create(
                 model=self.model,
-
                 temperature=0.2,
                 top_p=0.9,
                 max_tokens=_MAX_ANSWER_TOKENS,
-
-                messages=[
-                    {
-                        "role": "system",
-                        "content": system_prompt
-                    },
-                    {
-                        "role": "user",
-                        "content": user_prompt
-                    }
-                ],
+                messages=stream_messages,
                 stream=True,
                 extra_body=InferenceRouter.answer_extra_body(),
             )

--- a/server/rag/pipeline/retrieval/query_planner.py
+++ b/server/rag/pipeline/retrieval/query_planner.py
@@ -941,6 +941,19 @@ How many core courses are in the first semester of M.Tech EC (2022-23)?
 If no specific year is mentioned in the question, omit "rule_year" entirely.
 """
 
+def resolve_continuation_query(query: str, history: list = None) -> str:
+    """Rewrite continuation prompts ('continue', 'more', 'go on') using the previous user topic in history."""
+    if not query or not history:
+        return query
+    q_clean = query.strip().lower().rstrip(".!?")
+    continuation_keywords = {"continue", "more", "go on", "tell me more", "expand on that", "keep going", "what else"}
+    if q_clean in continuation_keywords:
+        last_user = next((h["content"] for h in reversed(history) if h.get("role") == "user" and h.get("content")), "")
+        if last_user:
+            return f"{last_user} (continue details)"
+    return query
+
+
 class QueryPlanner:
 
     def __init__(self):
@@ -952,7 +965,8 @@ class QueryPlanner:
             os.getenv("GROQ_MODEL", "Qwen/Qwen3-32B-AWQ")
         )
 
-    def plan(self, query, academic_scope=None):
+    def plan(self, query, academic_scope=None, history=None):
+        effective_query = resolve_continuation_query(query, history)
 
         scope_hint = ""
         if academic_scope is not None:
@@ -981,7 +995,7 @@ class QueryPlanner:
                     },
                     {
                         "role": "user",
-                        "content": scope_hint + "\nUser query: " + query
+                        "content": scope_hint + "\nUser query: " + effective_query
                     }
                 ],
                 extra_body=InferenceRouter.no_think_extra_body(),


### PR DESCRIPTION
### Summary of Multi-Turn & Memory Fixes Implemented

1. **Continuation Query Resolution (`server/rag/pipeline/retrieval/query_planner.py`):**
   - Implemented `resolve_continuation_query()` to automatically rewrite single-word continuation prompts (`"continue"`, `"more"`, `"go on"`, `"tell me more"`) using the preceding user query in `history`.
   - Prevents vector search from executing on isolated continuation keywords, eliminating hallucinated branch summaries.

2. **Native Chat History Messages Formatting (`server/rag/pipeline/generation/answer_generator.py`):**
   - Updated `AnswerGenerator.generate()` and `_generate_streaming()` to assemble multi-turn conversation history directly into the LLM `messages` payload (`{"role": "user"|"assistant", "content": "..."}`).
   - Ensures vLLM maintains full conversational context across turns.
