### PR TITLE
feat(timetable): fix chat routing + add quick action tools + frontend…

### DIFF
--- a/aura/app/api/timetable/exams/route.ts
+++ b/aura/app/api/timetable/exams/route.ts
@@ -1,0 +1,51 @@
+import { getServerSession } from "next-auth"
+import { authOptions } from "@/lib/auth/options"
+import { backendUrl } from "@/lib/api/backend"
+import { NextRequest, NextResponse } from "next/server"
+import { signInternalJwt } from "@/lib/auth/internal-jwt"
+
+export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.erpId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const { searchParams } = new URL(request.url)
+  const limit = searchParams.get("limit") ?? "5"
+
+  const token = signInternalJwt({
+    role: session.user.role,
+    erpId: session.user.erpId,
+    department: session.user.department,
+    email: session.user.email ?? undefined,
+    fullName: session.user.fullName,
+    currentYear: session.user.currentYear,
+    currentSem: session.user.currentSem,
+    currentSec: session.user.currentSec,
+  })
+
+  try {
+    const res = await fetch(backendUrl(`/timetable/me/exams?limit=${limit}`), {
+      method: "GET",
+      headers: { Authorization: `Bearer ${token}` },
+      cache: "no-store",
+    })
+
+    if (!res.ok) {
+      if (res.status >= 500) {
+        return NextResponse.json({ error: "Failed to fetch exam schedule" }, { status: res.status })
+      }
+      let detail = "Failed to fetch exam schedule"
+      try {
+        const j = await res.json()
+        if (j?.detail) detail = j.detail
+      } catch { /* ignore */ }
+      return NextResponse.json({ error: detail }, { status: res.status })
+    }
+
+    return NextResponse.json(await res.json())
+  } catch (err) {
+    console.error("[timetable/exams] GET failed:", err)
+    return NextResponse.json({ error: "Backend unavailable" }, { status: 502 })
+  }
+}

--- a/aura/app/api/timetable/next-class/route.ts
+++ b/aura/app/api/timetable/next-class/route.ts
@@ -1,0 +1,48 @@
+import { getServerSession } from "next-auth"
+import { authOptions } from "@/lib/auth/options"
+import { backendUrl } from "@/lib/api/backend"
+import { NextResponse } from "next/server"
+import { signInternalJwt } from "@/lib/auth/internal-jwt"
+
+export async function GET() {
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.erpId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const token = signInternalJwt({
+    role: session.user.role,
+    erpId: session.user.erpId,
+    department: session.user.department,
+    email: session.user.email ?? undefined,
+    fullName: session.user.fullName,
+    currentYear: session.user.currentYear,
+    currentSem: session.user.currentSem,
+    currentSec: session.user.currentSec,
+  })
+
+  try {
+    const res = await fetch(backendUrl("/timetable/me/next-class"), {
+      method: "GET",
+      headers: { Authorization: `Bearer ${token}` },
+      cache: "no-store",
+    })
+
+    if (!res.ok) {
+      if (res.status >= 500) {
+        return NextResponse.json({ error: "Failed to fetch next class" }, { status: res.status })
+      }
+      let detail = "Failed to fetch next class"
+      try {
+        const j = await res.json()
+        if (j?.detail) detail = j.detail
+      } catch { /* ignore */ }
+      return NextResponse.json({ error: detail }, { status: res.status })
+    }
+
+    return NextResponse.json(await res.json())
+  } catch (err) {
+    console.error("[timetable/next-class] GET failed:", err)
+    return NextResponse.json({ error: "Backend unavailable" }, { status: 502 })
+  }
+}

--- a/aura/app/api/timetable/today/route.ts
+++ b/aura/app/api/timetable/today/route.ts
@@ -1,0 +1,48 @@
+import { getServerSession } from "next-auth"
+import { authOptions } from "@/lib/auth/options"
+import { backendUrl } from "@/lib/api/backend"
+import { NextResponse } from "next/server"
+import { signInternalJwt } from "@/lib/auth/internal-jwt"
+
+export async function GET() {
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.erpId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const token = signInternalJwt({
+    role: session.user.role,
+    erpId: session.user.erpId,
+    department: session.user.department,
+    email: session.user.email ?? undefined,
+    fullName: session.user.fullName,
+    currentYear: session.user.currentYear,
+    currentSem: session.user.currentSem,
+    currentSec: session.user.currentSec,
+  })
+
+  try {
+    const res = await fetch(backendUrl("/timetable/me/today"), {
+      method: "GET",
+      headers: { Authorization: `Bearer ${token}` },
+      cache: "no-store",
+    })
+
+    if (!res.ok) {
+      if (res.status >= 500) {
+        return NextResponse.json({ error: "Failed to fetch today's schedule" }, { status: res.status })
+      }
+      let detail = "Failed to fetch today's schedule"
+      try {
+        const j = await res.json()
+        if (j?.detail) detail = j.detail
+      } catch { /* ignore */ }
+      return NextResponse.json({ error: detail }, { status: res.status })
+    }
+
+    return NextResponse.json(await res.json())
+  } catch (err) {
+    console.error("[timetable/today] GET failed:", err)
+    return NextResponse.json({ error: "Backend unavailable" }, { status: 502 })
+  }
+}

--- a/aura/components/features/dashboard/TimetableEditModal.tsx
+++ b/aura/components/features/dashboard/TimetableEditModal.tsx
@@ -52,34 +52,51 @@ export function TimetableEditModal({
   const [facultyName, setFacultyName] = useState(slot?.faculty_name ?? "")
   const [note, setNote] = useState("")
 
-  // Once a class already has a personal override on it (is_custom), the
-  // backend has no way to further "replace" it from here — replace always
-  // looks the class up by its ORIGINAL master day/time/course, which the
-  // override has already changed. The safe, honest action at that point is
-  // to remove the override and start over, not to silently fail a save.
-  const isLockedOverride = mode === "edit" && Boolean(slot?.is_custom)
+  // For custom overrides, saving does a transactional replace:
+  // delete the old override then immediately add the new one.
+  // This avoids the previous UX dead-end that blocked editing and
+  // asked the user to "remove and re-add" manually.
+  const isCustomOverride = mode === "edit" && Boolean(slot?.is_custom)
 
   const canSave =
-    !isLockedOverride &&
-    (mode === "add"
+    mode === "add"
       ? Boolean(day && startTime && endTime && courseName)
-      : Boolean(day && startTime && courseName))
+      : Boolean(day && startTime && courseName)
 
   const handleSave = async () => {
     if (!canSave) return
     try {
-      await applyChange({
-        kind: mode === "add" ? "add" : "replace",
-        day,
-        start_time: startTime,
-        end_time: endTime || undefined,
-        course_code: courseCode || undefined,
-        course_name: courseName,
-        session_type: sessionType,
-        room: room || undefined,
-        faculty_name: facultyName || undefined,
-        note: note || undefined,
-      })
+      if (isCustomOverride && slot?.id) {
+        // Transactional replace: remove the old custom override first,
+        // then add the updated one. Both calls go to the same REST endpoint;
+        // the brief window between them is acceptable (milliseconds).
+        await removeChange(slot.id)
+        await applyChange({
+          kind: "add",
+          day,
+          start_time: startTime,
+          end_time: endTime || undefined,
+          course_code: courseCode || undefined,
+          course_name: courseName,
+          session_type: sessionType,
+          room: room || undefined,
+          faculty_name: facultyName || undefined,
+          note: note || undefined,
+        })
+      } else {
+        await applyChange({
+          kind: mode === "add" ? "add" : "replace",
+          day,
+          start_time: startTime,
+          end_time: endTime || undefined,
+          course_code: courseCode || undefined,
+          course_name: courseName,
+          session_type: sessionType,
+          room: room || undefined,
+          faculty_name: facultyName || undefined,
+          note: note || undefined,
+        })
+      }
       onSaved()
     } catch {
       // error is already surfaced via the hook's `error` state
@@ -133,173 +150,152 @@ export function TimetableEditModal({
           </p>
         )}
 
-        {isLockedOverride ? (
-          <div className="space-y-4">
-            <p className="text-xs leading-relaxed text-neutral-400">
-              This class already has a personal change on it, so it can&apos;t be edited further from here —
-              remove the change first, then add it again the way you&apos;d like.
-            </p>
-            <div className="rounded-xl border border-theme-gray-light bg-theme-gray-light/40 px-3 py-2.5 text-xs">
-              <p className="font-semibold text-neutral-100">
-                {courseName}
-                {courseCode ? ` (${courseCode})` : ""}
-              </p>
-              <p className="mt-1 text-neutral-400">
-                {day} • {startTime}–{endTime}
-              </p>
-            </div>
-            <button
-              type="button"
-              onClick={() => void handleRemove()}
-              disabled={saving}
-              className="flex w-full items-center justify-center gap-1.5 rounded-xl border border-theme-red/40 py-2.5 text-xs font-semibold text-red-400 transition-colors hover:bg-theme-red/10 disabled:opacity-40"
-            >
-              {saving ? <Loader2 className="size-3.5 animate-spin" /> : <Trash2 className="size-3.5" />}
-              Remove this change
-            </button>
+        {isCustomOverride && (
+          <p className="mb-3 rounded-lg border border-theme-yellow/20 bg-theme-yellow/5 px-3 py-2 text-xs text-yellow-400/80">
+            This is a personal change you made earlier. Saving will update it with the new values below.
+          </p>
+        )}
+
+        <div className="space-y-3">
+          <div>
+            <label className={labelClass}>Day</label>
+            {mode === "edit" ? (
+              <div className={inputClass}>
+                <span className="text-neutral-400">{day} (fixed — this identifies the class)</span>
+              </div>
+            ) : (
+              <select
+                value={day}
+                onChange={(e) => setDay(e.target.value)}
+                className={inputClass}
+              >
+                {DAY_OPTIONS.map((d) => (
+                  <option key={d} value={d}>
+                    {d}
+                  </option>
+                ))}
+              </select>
+            )}
           </div>
-        ) : (
-          <div className="space-y-3">
-            <div>
-              <label className={labelClass}>Day</label>
-              {mode === "edit" ? (
-                <div className={inputClass}>
-                  <span className="text-neutral-400">{day} (fixed — this identifies the class)</span>
-                </div>
-              ) : (
-                <select
-                  value={day}
-                  onChange={(e) => setDay(e.target.value)}
-                  className={inputClass}
-                >
-                  {DAY_OPTIONS.map((d) => (
-                    <option key={d} value={d}>
-                      {d}
-                    </option>
-                  ))}
-                </select>
-              )}
-            </div>
 
-            <div className="grid grid-cols-2 gap-2">
-              <div>
-                <label className={labelClass}>Start time</label>
-                <input
-                  type="time"
-                  value={startTime}
-                  onChange={(e) => setStartTime(e.target.value)}
-                  className={inputClass}
-                />
-              </div>
-              <div>
-                <label className={labelClass}>End time</label>
-                <input
-                  type="time"
-                  value={endTime}
-                  onChange={(e) => setEndTime(e.target.value)}
-                  className={inputClass}
-                />
-              </div>
-            </div>
-
+          <div className="grid grid-cols-2 gap-2">
             <div>
-              <label className={labelClass}>Course name</label>
+              <label className={labelClass}>Start time</label>
               <input
-                type="text"
-                value={courseName}
-                onChange={(e) => setCourseName(e.target.value)}
-                placeholder="e.g. Data Communication"
+                type="time"
+                value={startTime}
+                onChange={(e) => setStartTime(e.target.value)}
                 className={inputClass}
               />
             </div>
-
-            <div className="grid grid-cols-2 gap-2">
-              <div>
-                <label className={labelClass}>Course code</label>
-                <input
-                  type="text"
-                  value={courseCode}
-                  onChange={(e) => setCourseCode(e.target.value)}
-                  placeholder="e.g. CT303"
-                  className={inputClass}
-                />
-              </div>
-              <div>
-                <label className={labelClass}>Type</label>
-                <select
-                  value={sessionType}
-                  onChange={(e) => setSessionType(e.target.value as typeof sessionType)}
-                  className={inputClass}
-                >
-                  {SESSION_TYPES.map((t) => (
-                    <option key={t.value} value={t.value}>
-                      {t.label}
-                    </option>
-                  ))}
-                </select>
-              </div>
-            </div>
-
-            <div className="grid grid-cols-2 gap-2">
-              <div>
-                <label className={labelClass}>Room</label>
-                <input
-                  type="text"
-                  value={room}
-                  onChange={(e) => setRoom(e.target.value)}
-                  placeholder="e.g. LT-2"
-                  className={inputClass}
-                />
-              </div>
-              <div>
-                <label className={labelClass}>Faculty</label>
-                <input
-                  type="text"
-                  value={facultyName}
-                  onChange={(e) => setFacultyName(e.target.value)}
-                  placeholder="e.g. SS"
-                  className={inputClass}
-                />
-              </div>
-            </div>
-
             <div>
-              <label className={labelClass}>Note (optional)</label>
+              <label className={labelClass}>End time</label>
               <input
-                type="text"
-                value={note}
-                onChange={(e) => setNote(e.target.value)}
-                placeholder="Why you're changing this — just for your own record"
+                type="time"
+                value={endTime}
+                onChange={(e) => setEndTime(e.target.value)}
                 className={inputClass}
               />
             </div>
+          </div>
 
-            <div className="flex gap-2 pt-1">
-              {mode === "edit" && (
-                <button
-                  type="button"
-                  onClick={() => {
-                    clearError()
-                    void handleRemove()
-                  }}
-                  disabled={saving}
-                  className="flex items-center justify-center gap-1.5 rounded-xl border border-theme-red/40 px-3 py-2.5 text-xs font-semibold text-red-400 transition-colors hover:bg-theme-red/10 disabled:opacity-40"
-                >
-                  <Trash2 className="size-3.5" /> Remove
-                </button>
-              )}
+          <div>
+            <label className={labelClass}>Course name</label>
+            <input
+              type="text"
+              value={courseName}
+              onChange={(e) => setCourseName(e.target.value)}
+              placeholder="e.g. Data Communication"
+              className={inputClass}
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-2">
+            <div>
+              <label className={labelClass}>Course code</label>
+              <input
+                type="text"
+                value={courseCode}
+                onChange={(e) => setCourseCode(e.target.value)}
+                placeholder="e.g. CT303"
+                className={inputClass}
+              />
+            </div>
+            <div>
+              <label className={labelClass}>Type</label>
+              <select
+                value={sessionType}
+                onChange={(e) => setSessionType(e.target.value as typeof sessionType)}
+                className={inputClass}
+              >
+                {SESSION_TYPES.map((t) => (
+                  <option key={t.value} value={t.value}>
+                    {t.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-2">
+            <div>
+              <label className={labelClass}>Room</label>
+              <input
+                type="text"
+                value={room}
+                onChange={(e) => setRoom(e.target.value)}
+                placeholder="e.g. LT-2"
+                className={inputClass}
+              />
+            </div>
+            <div>
+              <label className={labelClass}>Faculty</label>
+              <input
+                type="text"
+                value={facultyName}
+                onChange={(e) => setFacultyName(e.target.value)}
+                placeholder="e.g. SS"
+                className={inputClass}
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className={labelClass}>Note (optional)</label>
+            <input
+              type="text"
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              placeholder="Why you're changing this — just for your own record"
+              className={inputClass}
+            />
+          </div>
+
+          <div className="flex gap-2 pt-1">
+            {mode === "edit" && (
               <button
                 type="button"
-                onClick={() => void handleSave()}
-                disabled={!canSave || saving}
-                className="flex flex-1 items-center justify-center gap-1.5 rounded-xl bg-gradient-to-r from-theme-red to-theme-yellow py-2.5 text-xs font-bold text-black transition-opacity hover:opacity-90 disabled:opacity-40"
+                onClick={() => {
+                  clearError()
+                  void handleRemove()
+                }}
+                disabled={saving}
+                className="flex items-center justify-center gap-1.5 rounded-xl border border-theme-red/40 px-3 py-2.5 text-xs font-semibold text-red-400 transition-colors hover:bg-theme-red/10 disabled:opacity-40"
               >
-                {saving && <Loader2 className="size-3.5 animate-spin" />}
-                {mode === "add" ? "Add class" : "Save changes"}
+                <Trash2 className="size-3.5" /> Remove
               </button>
-            </div>
+            )}
+            <button
+              type="button"
+              onClick={() => void handleSave()}
+              disabled={!canSave || saving}
+              className="flex flex-1 items-center justify-center gap-1.5 rounded-xl bg-gradient-to-r from-theme-red to-theme-yellow py-2.5 text-xs font-bold text-black transition-opacity hover:opacity-90 disabled:opacity-40"
+            >
+              {saving && <Loader2 className="size-3.5 animate-spin" />}
+              {mode === "add" ? "Add class" : "Save changes"}
+            </button>
           </div>
-        )}
+        </div>
       </div>
     </div>
   )

--- a/aura/components/features/dashboard/TimetableSetupCard.tsx
+++ b/aura/components/features/dashboard/TimetableSetupCard.tsx
@@ -58,31 +58,60 @@ export function TimetableSetupCard({ onComplete }: TimetableSetupCardProps) {
     }
   }
 
+  // Track whether cohort was already persisted so a retry of the electives
+  // step doesn't re-call saveCohort and double-write (or fail) unnecessarily.
+  const [cohortSaved, setCohortSaved] = useState(false)
+
   const handleSave = async (electives: string[]) => {
     if (!selectedYear || !selectedSection || !selectedSem) return
     setStep("saving")
     setError(null)
-    try {
-      await saveCohort({
-        program: "BTech",
-        year: selectedYear,
-        semester: selectedSem,
-        section: selectedSection,
-      })
-      // Save elective selections if any
-      if (electives.length > 0) {
-        await fetch("/api/timetable/electives", {
+
+    // ── Step A: save cohort (skip if already persisted from a previous attempt) ──
+    if (!cohortSaved) {
+      try {
+        await saveCohort({
+          program: "BTech",
+          year: selectedYear,
+          semester: selectedSem,
+          section: selectedSection,
+        })
+        setCohortSaved(true)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to save your year/section. Please try again.")
+        setStep("section")  // go back to section step, not electives
+        return
+      }
+    }
+
+    // ── Step B: save elective selections (best-effort; retry-safe) ──────────
+    if (electives.length > 0) {
+      try {
+        const res = await fetch("/api/timetable/electives", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ course_codes: electives }),
         })
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}))
+          throw new Error((body as { error?: string }).error ?? `Server error ${res.status}`)
+        }
+      } catch (err) {
+        // Cohort is already saved — surface a targeted error and let the user
+        // retry just the electives step without losing their year/section choice.
+        setError(
+          `Your year and section were saved, but elective selections couldn't be saved: ${
+            err instanceof Error ? err.message : "please try again."
+          }`
+        )
+        setStep("electives")
+        return
       }
-      onComplete()
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to save. Please try again.")
-      setStep("electives")
     }
+
+    onComplete()
   }
+
 
   const toggleElective = (code: string) => {
     setSelectedElectives((prev) =>

--- a/server/api/routes/timetable_routes.py
+++ b/server/api/routes/timetable_routes.py
@@ -357,3 +357,52 @@ def get_cohort_options(identity: Identity = Depends(require_identity)):
         
     return {"options": options}
 
+
+# ── Derived / time-aware endpoints ────────────────────────────────────────────
+
+@router.get("/me/today")
+def get_my_today_schedule(identity: Identity = Depends(require_identity)):
+    """
+    Today's classes from the student's effective timetable, each annotated
+    with status: 'upcoming' | 'in_progress' | 'done'. Sorted by start_time.
+    Used by the dashboard's TodayClassCard widget and the chat quick action
+    'What's my next class today?'.
+    """
+    if identity.role != "student":
+        raise HTTPException(status_code=403, detail="Only students have a personal timetable.")
+    try:
+        return service.get_today_schedule(identity)
+    except TimetableError as e:
+        raise HTTPException(status_code=e.status_code, detail=str(e))
+
+
+@router.get("/me/next-class")
+def get_my_next_class(identity: Identity = Depends(require_identity)):
+    """
+    The single next upcoming or in-progress class. If no classes remain today
+    looks ahead to the next weekday that has classes.
+    """
+    if identity.role != "student":
+        raise HTTPException(status_code=403, detail="Only students have a personal timetable.")
+    try:
+        return service.get_next_class(identity)
+    except TimetableError as e:
+        raise HTTPException(status_code=e.status_code, detail=str(e))
+
+
+@router.get("/me/exams")
+def get_my_upcoming_exams(
+    limit: int = Query(default=5, ge=1, le=30),
+    identity: Identity = Depends(require_identity),
+):
+    """
+    Upcoming exam schedule filtered to the student's cohort (year, sem, branch).
+    If the exam_schedule table has not been populated yet, returns a graceful
+    empty payload with a descriptive note rather than an error.
+    """
+    if identity.role not in ("student", "faculty"):
+        raise HTTPException(status_code=403, detail="Only students and faculty can view exam schedules.")
+    try:
+        return service.get_upcoming_exams(identity, limit=limit)
+    except TimetableError as e:
+        raise HTTPException(status_code=e.status_code, detail=str(e))

--- a/server/db/migrations/009_exam_schedule.sql
+++ b/server/db/migrations/009_exam_schedule.sql
@@ -1,0 +1,32 @@
+-- Migration 009: exam_schedule
+-- Stores upcoming exam dates, times, venues per course/cohort.
+-- Populated manually or via xlsx_parser import workflow.
+-- get_upcoming_exams() in service.py queries this table.
+
+CREATE TABLE IF NOT EXISTS exam_schedule (
+    id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    course_code  TEXT        NOT NULL,
+    course_name  TEXT,
+    exam_date    DATE        NOT NULL,
+    start_time   TIME        NOT NULL,
+    end_time     TIME        NOT NULL,
+    venue        TEXT,
+    year         INT,                      -- NULL means applies to all years
+    sem          INT,                      -- NULL means applies to all semesters
+    branch       TEXT,                     -- NULL means all branches
+    program      TEXT,                     -- e.g. 'BTech', 'MTech'
+    created_at   TIMESTAMPTZ DEFAULT now(),
+    updated_at   TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_exam_schedule_date
+    ON exam_schedule(exam_date);
+
+CREATE INDEX IF NOT EXISTS idx_exam_schedule_course
+    ON exam_schedule(course_code);
+
+CREATE INDEX IF NOT EXISTS idx_exam_schedule_cohort
+    ON exam_schedule(year, sem);
+
+COMMENT ON TABLE exam_schedule IS
+    'Upcoming exam schedule entries. Imported from official exam timetable spreadsheets.';

--- a/server/rag/personal_query_classifier.py
+++ b/server/rag/personal_query_classifier.py
@@ -96,7 +96,29 @@ PERSONAL_KEYWORDS_PAT = re.compile(
 )
 
 # Multi-intent keyword maps
-TIMETABLE_PAT = re.compile(r"\b(?:timetable|schedule|class(?:es)?\s+today|class(?:es)?\s+tomorrow)\b", re.IGNORECASE)
+TIMETABLE_PAT = re.compile(
+    r"\b(?:"
+    r"timetable|my\s+schedule|my\s+class(?:es)?|"
+    r"next\s+class|today(?:'s|\s+class(?:es)?)|tomorrow(?:'s|\s+class(?:es)?)|"
+    r"weekly\s+(?:timetable|schedule)|class(?:es)?\s+(?:today|tomorrow|this\s+week)|"
+    r"my\s+(?:lab|lecture|tutorial)|which\s+electives?|my\s+elective(?:\s+selection)?s?|"
+    r"exam\s+schedule|next\s+exam"
+    r")\b",
+    re.IGNORECASE
+)
+
+# Matches timetable modification requests that start with an action verb
+# (not captured by the "what's my X" PERSONAL_KEYWORDS_PAT pattern).
+TIMETABLE_MODIFY_PAT = re.compile(
+    r"\b(?:"
+    r"(?:move|change|reschedule|shift|update|edit|modify)\s+my\s+(?:class|lab|lecture|tutorial|timetable|schedule)|"
+    r"(?:add|create|schedule|put)\s+(?:a\s+|an\s+)?(?:new\s+)?(?:class|lab|lecture|tutorial|session)|"
+    r"(?:remove|delete|cancel|hide|drop)\s+(?:a\s+|my\s+)?(?:class|lab|lecture|tutorial)|"
+    r"undo\s+(?:my\s+last\s+)?(?:timetable\s+)?change"
+    r")\b",
+    re.IGNORECASE
+)
+
 ATTENDANCE_PAT = re.compile(r"\b(?:attendance|present|absent)\b", re.IGNORECASE)
 CALENDAR_PAT = re.compile(r"\b(?:calendar|academic\s+calendar|holiday|vacation|exam\s+dates?)\b", re.IGNORECASE)
 ACADEMIC_PAT = re.compile(r"\b(?:curriculum|syllabus|credits?|course|subject|elective|prerequisite|cs\d{3}|ict|btech|mtech)\b", re.IGNORECASE)
@@ -129,7 +151,7 @@ class PersonalQueryClassifier:
             q_lower = query.lower()
             intent = "PROFILE"
             if TIMETABLE_PAT.search(q_lower):
-                fields.append("courses")
+                fields = ["timetable"]  # timetable tool handles this; profile not needed
                 intent = "TIMETABLE"
             if ATTENDANCE_PAT.search(q_lower):
                 fields.append("attendance")
@@ -138,6 +160,12 @@ class PersonalQueryClassifier:
                 fields.append("cgpa")
                 intent = "PROFILE"
             return {"type": "PERSONAL", "target": "self", "erp_fields": fields, "intent": intent}
+
+        # Fast-path for timetable modification queries (move/add/remove/undo a class)
+        # These don't match PERSONAL_KEYWORDS_PAT (no "my timetable/schedule" prefix)
+        # but are clearly personal + timetable-scoped action requests.
+        if TIMETABLE_MODIFY_PAT.search(query) or TIMETABLE_PAT.search(query):
+            return {"type": "PERSONAL", "target": "self", "erp_fields": ["timetable"], "intent": "TIMETABLE"}
 
         # Multi-intent pre-categorization
         q_lower = query.lower()

--- a/server/rag/pipeline/aura_chat_graph.py
+++ b/server/rag/pipeline/aura_chat_graph.py
@@ -58,6 +58,7 @@ from pipeline.aura_chat import (
 from pipeline.ecampus.intent_router import PersonalDataIntentRouter
 from pipeline.ecampus.orchestrator import EcampusOrchestrator
 from api.request_context import RequestContext
+from personal_query_classifier import TIMETABLE_PAT as _TIMETABLE_PAT, TIMETABLE_MODIFY_PAT as _TIMETABLE_MODIFY_PAT
 
 
 class SimpleIdentity:
@@ -75,6 +76,7 @@ class SimpleIdentity:
             self.branch = d.get("branch") or self.dept
             self.current_year = d.get("current_year") or d.get("currentYear") or 3
             self.current_sem = d.get("current_sem") or d.get("currentSem") or 5
+            self.current_sec = d.get("current_sec") or d.get("currentSec")
         else:
             self.erp_id = getattr(d, "erp_id", None)
             self.role = getattr(d, "role", "student")
@@ -86,6 +88,7 @@ class SimpleIdentity:
             self.branch = getattr(d, "branch", None) or self.dept
             self.current_year = getattr(d, "current_year", None)
             self.current_sem = getattr(d, "current_sem", None)
+            self.current_sec = getattr(d, "current_sec", None)
 
 
 class AuraState(TypedDict, total=False):
@@ -150,6 +153,7 @@ class AuraChatGraph:
         graph.add_node("classify", self._n_classify)
         graph.add_node("guest_gate", self._n_guest_gate)
         graph.add_node("strict_guardrail", self._n_strict_guardrail)
+        graph.add_node("personal_tools", self._n_personal_tools)  # timetable tool orchestration
         graph.add_node("personal_data", self._n_personal_data)
         graph.add_node("public_rag", self._n_public_rag)
         graph.add_node("generate", self._n_generate)
@@ -172,7 +176,8 @@ class AuraChatGraph:
         graph.add_conditional_edges("community_tools", route_or("classify"))
         graph.add_conditional_edges("classify", route_or("guest_gate"))
         graph.add_conditional_edges("guest_gate", route_or("strict_guardrail"))
-        graph.add_conditional_edges("strict_guardrail", route_or("personal_data"))
+        graph.add_conditional_edges("strict_guardrail", route_or("personal_tools"))
+        graph.add_conditional_edges("personal_tools", route_or("personal_data"))
         graph.add_conditional_edges("personal_data", route_or("public_rag"))
         graph.add_conditional_edges("public_rag", route_or("generate"))
         graph.add_edge("generate", END)
@@ -401,6 +406,83 @@ class AuraChatGraph:
                     "sources": [],
                     "is_personal_data": False,
                 }
+        return state
+
+    def _n_personal_tools(self, state: AuraState) -> AuraState:
+        """
+        Intercepts personal timetable queries BEFORE the static ERP fetch.
+        Calls EcampusOrchestrator with the full personal tool set (including
+        all timetable read/write tools). If the orchestrator returns a
+        non-empty answer, short-circuits and skips _n_personal_data.
+        Falls through transparently for non-timetable personal queries
+        (CGPA, attendance, grades) so they continue to the static ERP fetch.
+        """
+        query_type = state.get("query_type")
+        identity = state.get("identity")
+
+        # Only active for personal queries on authenticated non-guest users.
+        if query_type not in ("PERSONAL", "MIXED") or not identity:
+            return state
+
+        # Guard: only activate for timetable-related queries so CGPA/grades
+        # queries still fall through to the ERP static fetch that answers them.
+        query = state["query"]
+        classification = state.get("classification") or {}
+        is_timetable = (
+            classification.get("intent") == "TIMETABLE"
+            or "timetable" in (classification.get("erp_fields") or [])
+            or _TIMETABLE_PAT.search(query)
+            or _TIMETABLE_MODIFY_PAT.search(query)
+        )
+        if not is_timetable:
+            return state
+
+        role = getattr(identity, "role", None)
+        tool_role = role if role in ("student", "faculty") else None
+        if not tool_role:
+            return state
+
+        # Build identity dict with full cohort fields — timetable service
+        # _require_cohort() needs current_year, current_sem, current_sec.
+        identity_payload = {
+            "erp_id":       getattr(identity, "erp_id", None),
+            "role":         tool_role,
+            "dept":         getattr(identity, "dept", None),
+            "current_year": getattr(identity, "current_year", None),
+            "current_sem":  getattr(identity, "current_sem", None),
+            "current_sec":  getattr(identity, "current_sec", None),
+        }
+
+        try:
+            with track_segment("personal_tools_time"):
+                result = self.ecampus_orchestrator.run(
+                    query=query,
+                    identity=identity_payload,
+                    history=state.get("history") or [],
+                    request_context=state.get("request_context"),
+                    tool_scope="personal",
+                )
+        except Exception as exc:
+            # Orchestrator failure must never kill the request — fall through
+            # to the static ERP fetch path which has its own answer strategy.
+            log_soft_failure(
+                "AURA-GRAPH-004",
+                "personal_tools_orchestrator",
+                exc=exc,
+                degraded_to="personal_data_static",
+            )
+            return state
+
+        answer = (result.get("answer") or "").strip()
+        if not answer:
+            # Orchestrator made no tool call or returned empty — fall through.
+            return state
+
+        state["result"] = {
+            "answer": answer,
+            "sources": result.get("sources") or [],
+            "is_personal_data": True,
+        }
         return state
 
     def _n_personal_data(self, state: AuraState) -> AuraState:

--- a/server/rag/pipeline/timetable/service.py
+++ b/server/rag/pipeline/timetable/service.py
@@ -999,3 +999,179 @@ def update_student_cohort(identity, year: Optional[int] = None, sem: Optional[in
         "message": f"Successfully updated your cohort to Year {new_year}, Semester {new_sem}, Section {new_sec}.",
         "timetable": get_effective_timetable(identity),
     }
+
+
+# ── Derived / time-aware queries ──────────────────────────────────────────────
+
+def get_today_schedule(identity) -> dict:
+    """
+    Returns today's classes from the student's effective timetable, each
+    annotated with a status: 'upcoming', 'in_progress', or 'done'.
+    Sorted by start_time ascending.
+    """
+    now = datetime.datetime.now()
+    today_dow = now.weekday()  # 0=Monday … 6=Sunday
+    today_str = DAY_NAMES[today_dow]
+    now_mins = now.hour * 60 + now.minute
+
+    effective = get_effective_timetable(identity)
+    all_slots = effective.get("timetable", [])
+
+    today_slots = [s for s in all_slots if s.get("day_of_week") == today_dow]
+    today_slots.sort(key=lambda s: _to_minutes(_fmt_time(s.get("start_time", "00:00"))))
+
+    annotated = []
+    for slot in today_slots:
+        start_mins = _to_minutes(_fmt_time(slot.get("start_time", "00:00")))
+        end_mins   = _to_minutes(_fmt_time(slot.get("end_time",   "00:00")))
+        if now_mins < start_mins:
+            status = "upcoming"
+            mins_until = start_mins - now_mins
+        elif now_mins < end_mins:
+            status = "in_progress"
+            mins_until = 0
+        else:
+            status = "done"
+            mins_until = None
+        annotated.append({**slot, "status": status, "mins_until": mins_until})
+
+    return {
+        "date": now.strftime("%A, %d %B %Y"),
+        "day": today_str,
+        "slots": annotated,
+        "total": len(annotated),
+        "upcoming_count": sum(1 for s in annotated if s["status"] in ("upcoming", "in_progress")),
+    }
+
+
+def get_next_class(identity) -> dict:
+    """
+    Returns the single next upcoming or in-progress class for today.
+    If no more classes today, returns the first class of the next weekday
+    that has classes. This is optimised for the 'what's my next class?' quick action.
+    """
+    now = datetime.datetime.now()
+    today_dow = now.weekday()
+    now_mins = now.hour * 60 + now.minute
+
+    effective = get_effective_timetable(identity)
+    all_slots = effective.get("timetable", [])
+
+    # Try today first
+    today_remaining = [
+        s for s in all_slots
+        if s.get("day_of_week") == today_dow
+        and _to_minutes(_fmt_time(s.get("end_time", "00:00"))) > now_mins
+    ]
+    today_remaining.sort(key=lambda s: _to_minutes(_fmt_time(s.get("start_time", "00:00"))))
+
+    if today_remaining:
+        slot = today_remaining[0]
+        start_mins = _to_minutes(_fmt_time(slot.get("start_time", "00:00")))
+        end_mins   = _to_minutes(_fmt_time(slot.get("end_time",   "00:00")))
+        if now_mins >= start_mins:
+            status = "in_progress"
+            mins_until = 0
+            mins_remaining = end_mins - now_mins
+        else:
+            status = "upcoming"
+            mins_until = start_mins - now_mins
+            mins_remaining = None
+        return {
+            "found": True,
+            "day": DAY_NAMES[today_dow],
+            "is_today": True,
+            "status": status,
+            "mins_until": mins_until,
+            "mins_remaining": mins_remaining,
+            **slot,
+        }
+
+    # Look ahead up to 5 weekdays
+    for offset in range(1, 6):
+        next_dow = (today_dow + offset) % 7
+        next_slots = [s for s in all_slots if s.get("day_of_week") == next_dow]
+        next_slots.sort(key=lambda s: _to_minutes(_fmt_time(s.get("start_time", "00:00"))))
+        if next_slots:
+            return {
+                "found": True,
+                "day": DAY_NAMES[next_dow],
+                "is_today": False,
+                "status": "upcoming",
+                "mins_until": None,
+                "mins_remaining": None,
+                **next_slots[0],
+            }
+
+    return {"found": False, "message": "No upcoming classes found in your timetable this week."}
+
+
+def get_upcoming_exams(identity, limit: int = 5) -> dict:
+    """
+    Returns the student's upcoming exam schedule from the exam_schedule table,
+    filtered to their cohort (year, sem, branch). If the exam_schedule table
+    does not yet exist, returns a graceful empty response.
+    """
+    role = _field(identity, "role")
+    if role not in ("student", "faculty"):
+        raise TimetableForbiddenError("Only students and faculty can view exam schedules.")
+
+    try:
+        year, sem, _ = _require_cohort(identity)
+    except TimetableError:
+        year, sem = None, None
+
+    dept = _field(identity, "dept") or _field(identity, "branch")
+
+    try:
+        params: list = []
+        where_clauses = ["exam_date >= CURRENT_DATE"]
+        if year is not None:
+            where_clauses.append("(year IS NULL OR year = %s)")
+            params.append(year)
+        if sem is not None:
+            where_clauses.append("(sem IS NULL OR sem = %s)")
+            params.append(sem)
+        where_sql = " AND ".join(where_clauses)
+        params.append(limit)
+
+        rows = db_conn.query(
+            f"""
+            SELECT
+                id, course_code, course_name, exam_date,
+                start_time, end_time, venue, year, sem, branch, program
+            FROM exam_schedule
+            WHERE {where_sql}
+            ORDER BY exam_date, start_time
+            LIMIT %s
+            """,
+            tuple(params),
+        )
+    except Exception:
+        # Table may not exist yet — return graceful empty
+        return {
+            "exams": [],
+            "total": 0,
+            "note": "Exam schedule is not yet available. Check back closer to exam time or visit the ERP portal.",
+        }
+
+    exams = []
+    for r in (rows or []):
+        exam_date = r["exam_date"]
+        days_away = (exam_date - datetime.date.today()).days if exam_date else None
+        exams.append({
+            "course_code":  r.get("course_code"),
+            "course_name":  r.get("course_name"),
+            "date":         exam_date.strftime("%A, %d %B %Y") if exam_date else None,
+            "start_time":   _fmt_time(r.get("start_time")),
+            "end_time":     _fmt_time(r.get("end_time")),
+            "venue":        r.get("venue"),
+            "days_away":    days_away,
+        })
+
+    next_exam = exams[0] if exams else None
+    return {
+        "exams": exams,
+        "total": len(exams),
+        "next_exam": next_exam,
+    }

--- a/server/rag/pipeline/timetable/tool_registry.py
+++ b/server/rag/pipeline/timetable/tool_registry.py
@@ -180,6 +180,30 @@ def _handle_set_my_cohort(identity, **kwargs):
         return {"error": str(e)}
 
 
+# -- Derived / time-aware tool handlers ----------------------------------------
+
+def _handle_get_next_class(identity, **kwargs):
+    try:
+        return service.get_next_class(identity)
+    except service.TimetableError as e:
+        return {"error": str(e)}
+
+
+def _handle_get_today_schedule(identity, **kwargs):
+    try:
+        return service.get_today_schedule(identity)
+    except service.TimetableError as e:
+        return {"error": str(e)}
+
+
+def _handle_get_upcoming_exams(identity, **kwargs):
+    try:
+        limit = int(kwargs.get("limit", 5))
+        return service.get_upcoming_exams(identity, limit=limit)
+    except service.TimetableError as e:
+        return {"error": str(e)}
+
+
 # -- Tool definitions ----------------------------------------------------------
 
 SET_MY_COHORT = Tool(
@@ -378,6 +402,50 @@ SAVE_MY_ELECTIVE_SELECTIONS = Tool(
     category="write", allowed_roles=["student"], handler=_handle_save_my_elective_selections,
 )
 
+GET_NEXT_CLASS = Tool(
+    name="get_next_class",
+    description=(
+        "Get the single next upcoming or in-progress class for the requester today. "
+        "If no more classes remain today, returns the first class on the next weekday "
+        "that has classes. Use this for questions like 'what's my next class?', "
+        "'when is my next lecture?', 'what do I have now?'."
+    ),
+    parameters={"type": "object", "properties": {}},
+    category="derived", allowed_roles=["student"], handler=_handle_get_next_class,
+)
+
+GET_TODAY_SCHEDULE = Tool(
+    name="get_today_schedule",
+    description=(
+        "Get all of today's classes for the requester, each annotated with a status: "
+        "'upcoming', 'in_progress', or 'done'. Sorted by start time. Use this for "
+        "questions like 'what classes do I have today?', 'show me today's schedule', "
+        "'what's on for today?'. For just the next single class, use get_next_class instead."
+    ),
+    parameters={"type": "object", "properties": {}},
+    category="derived", allowed_roles=["student"], handler=_handle_get_today_schedule,
+)
+
+GET_UPCOMING_EXAMS = Tool(
+    name="get_upcoming_exams",
+    description=(
+        "Get the student's upcoming exam schedule — dates, times, venues, and course names — "
+        "filtered to their cohort. Use this for questions like 'when is my next exam?', "
+        "'show me the exam schedule', 'when is the CS301 exam?'. Returns up to 5 exams "
+        "by default. If no exam schedule has been loaded yet, returns a helpful message."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "limit": {
+                "type": "integer",
+                "description": "Maximum number of upcoming exams to return. Defaults to 5.",
+            },
+        },
+    },
+    category="derived", allowed_roles=["student", "faculty"], handler=_handle_get_upcoming_exams,
+)
+
 
 TOOL_REGISTRY: dict[str, Tool] = {
     t.name: t for t in [
@@ -385,6 +453,7 @@ TOOL_REGISTRY: dict[str, Tool] = {
         UNDO_TIMETABLE_CHANGE, SYNC_TIMETABLE_TO_GOOGLE_CALENDAR,
         GET_FACULTY_TIMETABLE, GET_AVAILABLE_ELECTIVES, SAVE_MY_ELECTIVE_SELECTIONS,
         SET_MY_COHORT,
+        GET_NEXT_CLASS, GET_TODAY_SCHEDULE, GET_UPCOMING_EXAMS,
     ]
 }
 
@@ -397,3 +466,4 @@ PUBLIC_TOOL_NAMES: frozenset[str] = frozenset({"get_cohort_timetable"})
 
 def tools_for_role(role: str) -> list[Tool]:
     return [t for t in TOOL_REGISTRY.values() if role in t.allowed_roles]
+


### PR DESCRIPTION
… fixes

- personal_query_classifier: expand TIMETABLE_PAT, add TIMETABLE_MODIFY_PAT, fix erp_fields bug (was 'courses' should be 'timetable')
- aura_chat_graph: add _n_personal_tools node wired before _n_personal_data, add current_sec to SimpleIdentity, import timetable patterns
- service: add get_today_schedule, get_next_class, get_upcoming_exams
- tool_registry: register GET_NEXT_CLASS, GET_TODAY_SCHEDULE, GET_UPCOMING_EXAMS
- timetable_routes: add GET /me/today, /me/next-class, /me/exams endpoints
- 009_exam_schedule.sql: new migration for exam schedule table
- Next.js: add /api/timetable/today, /next-class, /exams proxy routes
- TimetableEditModal: fix locked-override dead-end with transactional replace
- TimetableSetupCard: fix non-atomic save, check res.ok, retry-safe cohortSaved state