### PR TITLE
fix(rag): add on_profile_update parameter to AURA.ask wrapper

### DIFF
--- a/server/rag/rag.py
+++ b/server/rag/rag.py
@@ -21,6 +21,7 @@ class AURA:
         on_delta=None,
         summary=None,
         request_context=None,
+        on_profile_update=None,
     ):
         return self.chatbot.chat(
             query=question,
@@ -30,4 +31,5 @@ class AURA:
             on_delta=on_delta,
             summary=summary,
             request_context=request_context,
+            on_profile_update=on_profile_update,
         )


### PR DESCRIPTION
## Fix AURA.ask() on_profile_update Signature Compatibility

### 🚀 Overview
Adds `on_profile_update=None` to `AURA.ask()` in `server/rag/rag.py` and forwards it through to `self.chatbot.chat(...)`.

### 🐛 Problem Resolved
Prevents `TypeError: AURA.ask() got an unexpected keyword argument 'on_profile_update'` when `chat_routes.py` invokes `AURA.ask(..., on_profile_update=...)`.

### 🔒 Constraints Observed
- **Files Modified:** `server/rag/rag.py` ONLY.
- **Zero Merge Conflicts:** Branched cleanly off latest `origin/main`.
- **Signed Commit:** Verified SSH signature (`-S`).
