### PR TITLE
Revert "fix(retrieval): use embed_query abstraction in dual-path semantic retrieval and add on_profile_update to AURA.ask"

### DIFF
--- a/server/rag/pipeline/retrieval/retrieval_pipeline.py
+++ b/server/rag/pipeline/retrieval/retrieval_pipeline.py
@@ -328,6 +328,11 @@ class RetrievalPipeline:
                 else:
                     sem_vals = self._canonical_semester_values(raw_val)
                     val = sem_vals if sem_vals else [raw_val]
+            elif field == "course_code":
+                if isinstance(raw_val, list):
+                    val = [re.sub(r"[\s\-]", "", str(c)).upper() for c in raw_val if c]
+                else:
+                    val = [re.sub(r"[\s\-]", "", str(raw_val)).upper()]
             else:
                 val = raw_val
 
@@ -1268,7 +1273,25 @@ class RetrievalPipeline:
             for c in entity_list:
                 c["normalized_score"] = (c["entity_score"] - min_val) / val_range if val_range > 0 else 1.0
 
-        # 2. Semantic Path: Top-50 vector search (using Pinecone/Qdrant index query directly)
+        # 2. Semantic Path: Top-50 vector search (using Pinecone index query directly)
+        query_embedding = self.retriever.model.encode(
+            ["Represent this sentence for searching relevant passages: " + query],
+            normalize_embeddings=True,
+            convert_to_numpy=True
+        )
+        semantic_filter = {"authorization": {"$in": allowed_roles}} if allowed_roles else None
+        if os.getenv("DISABLE_DLS_FILTER", os.getenv("DISABLE_PINECONE_DLS_FILTER", "false")).lower() == "true":
+            semantic_filter = None
+
+        if self.retriever.index:
+            results = self.retriever.index.query(
+                vector=query_embedding[0].tolist(),
+                top_k=50,
+                include_metadata=True,
+                filter=semantic_filter
+            )
+        else:
+            results = {"matches": []}
         semantic_list = []
         if self.retriever.index is None:
             logger.info("Semantic retrieval disabled because the vector index is unavailable; continuing with entity-path results only.")

--- a/server/rag/rag.py
+++ b/server/rag/rag.py
@@ -21,6 +21,7 @@ class AURA:
         on_delta=None,
         summary=None,
         request_context=None,
+        on_profile_update=None,
     ):
         return self.chatbot.chat(
             query=question,
@@ -30,4 +31,5 @@ class AURA:
             on_delta=on_delta,
             summary=summary,
             request_context=request_context,
+            on_profile_update=on_profile_update,
         )


### PR DESCRIPTION
## 1. `rag.py` — removing `on_profile_update` breaks 100% of chats

The diff removes `on_profile_update` from `AURA.ask()`'s signature and its pass-through call. But `chat_routes.py` (the only caller) still does:

```python
result = get_aura().ask(
    question=body.question,
    ...
    on_profile_update=on_profile_update,   # still passed!
    ...
)
```

After this PR, that line raises `TypeError: ask() got an unexpected keyword argument 'on_profile_update'` — on every chat call, no exceptions. It's caught by `chat_routes.py`'s `try/except` in `_run()`, so it won't crash the server, but it turns into an `("error", exc)` SSE event for literally every message sent. This isn't an intermittent GPU-saturation failure like we diagnosed last time — this is a guaranteed, permanent break of the whole chat feature, and it's already merged to `main`.

The parameter is still very much alive downstream too — `AuraChatGraph.chat()` still takes `on_profile_update` and puts it in `initial_state`, and it's what drives the "auto-fill name from ERP" profile-update event on the frontend. So this wasn't a dead param being cleaned up; it's load-bearing, and only the `rag.py` wrapper's pass-through got deleted.

## 2. `retrieval_pipeline.py` — the "embed_query abstraction" doesn't appear to exist

The commit message claims this replaces manual embedding with an `embed_query` abstraction, but the diff shows the entire encode-and-query block deleted:

```python
query_embedding = self.retriever.model.encode([...], ...)
...
if self.retriever.index:
    results = self.retriever.index.query(vector=..., top_k=50, ...)
else:
    results = {"matches": []}
```

— and replaced with just an updated comment (`"Pinecone index query directly"` → `"Pinecone/Qdrant index query directly"`). The whole PR is **+1/−26 across both files**, which isn't consistent with actually swapping in a real abstraction call (that would typically net out closer to even). If nothing downstream re-defines `results` before it's used to build `semantic_list`, this is a `NameError` waiting to happen on the semantic retrieval path, or at best silently produces no semantic results depending on what's just below the shown diff. Worth checking the full current file to confirm `results` is defined before use.

## 3. `_make_clause` — `course_code` normalization silently dropped

The `elif field == "course_code":` branch (strips whitespace/dashes, uppercases) is deleted with nothing replacing it, so `course_code` now falls through to the generic `else: val = raw_val`. This is flagged in the code as "Priority 1 (highest specificity)" for course-specific queries — if your corpus metadata stores canonical codes like `"CS201"` and a query yields `"cs-201"` or `"CS 201"`, that filter will now silently miss. No abstraction or replacement logic covers this — it's just gone.

## Bottom line

This PR is not correct as merged. Recommend:
- **Immediately** restore `on_profile_update` in `rag.py`'s `ask()` (this is the urgent one — it's breaking prod right now) — or revert the commit outright.
- Check whether `results` is actually still defined in the semantic path before merge, or if that's genuinely dead/broken.
- Restore or replace the `course_code` normalization before this ships as "correct."