### PR TITLE
fix(calendar): restore connect prompt test stub

### DIFF
--- a/server/rag/pipeline/tests/test_calendar_connect_prompt.py
+++ b/server/rag/pipeline/tests/test_calendar_connect_prompt.py
@@ -80,7 +80,7 @@ def test_connect_required_surfaced_when_calendar_not_linked(monkeypatch):
     # With no linked calendar, the direct sync reports calendar_not_connected →
     # a structured connect CTA, with no LLM or request for timetable details.
     monkeypatch.setattr(
-        timetable_sync, "preview",
+        timetable_sync, "apply",
         lambda identity, **k: {"status": "calendar_not_connected", "message": "Not linked."},
     )
     orch = _no_llm_orch(monkeypatch)


### PR DESCRIPTION
The test stubbed timetable preview after explicit calendar sync requests switched to the apply path, so CI exercised the real fallback and never received the expected connect-required result. Stub the dispatched apply function so the test validates the structured CTA contract.