### PR TITLE
fix(ai): run full-query BM25 pass in dual-path retrieval

### DIFF
--- a/server/rag/pipeline/retrieval/retrieval_pipeline.py
+++ b/server/rag/pipeline/retrieval/retrieval_pipeline.py
@@ -1349,6 +1349,36 @@ class RetrievalPipeline:
                     }
                 entity_pool[chunk_id]["rrf_score"] += 1.0 / (60.0 + rank)
 
+        # Full-query lexical (BM25) pass. The per-entity loop above only runs
+        # BM25 for planner-extracted entities, so a query that carries strong
+        # keyword signal but yields no high-confidence entity (e.g. "what are
+        # the hostel rules", "course policy of EL470") reached this pool empty
+        # and fusion collapsed to pure dense search — which buries the exact
+        # document under near-duplicate chunks. Running BM25 on the raw query
+        # and folding it into the same RRF pool restores the lexical half of
+        # hybrid retrieval for every query, not just entity queries. The same
+        # authorization + academic-scope filter is applied so role/scope
+        # gating is never bypassed.
+        if getattr(self.retriever, "bm25", None):
+            lexical_filter = self._combine_filters(
+                {"authorization": {"$in": allowed_roles}} if allowed_roles else None,
+                self._academic_scope_filter(academic_scope),
+            )
+            lexical_results = self.retriever.bm25.retrieve(
+                query=query,
+                top_k=20,
+                metadata_filter=lexical_filter,
+                allowed_roles=allowed_roles,
+            )
+            for rank, res in enumerate(lexical_results, start=1):
+                chunk_id = res["id"]
+                if chunk_id not in entity_pool:
+                    entity_pool[chunk_id] = {
+                        "chunk": res,
+                        "rrf_score": 0.0
+                    }
+                entity_pool[chunk_id]["rrf_score"] += 1.0 / (60.0 + rank)
+
         entity_list = []
         for chunk_id, info in entity_pool.items():
             chunk_item = dict(info["chunk"])

--- a/server/rag/pipeline/tests/test_dls_pipeline.py
+++ b/server/rag/pipeline/tests/test_dls_pipeline.py
@@ -14,6 +14,9 @@ def _build_mocked_pipeline(mock_retriever_class):
     mock_retriever.index = MagicMock()
     mock_retriever.index.query.return_value = {"matches": []}
     mock_retriever.retrieve.return_value = []
+    # The dual path now runs a full-query BM25 pass; default it to empty so
+    # existing tests exercise the (unchanged) filter/fusion behaviour.
+    mock_retriever.bm25.retrieve.return_value = []
 
     pipeline = RetrievalPipeline()
 
@@ -67,3 +70,31 @@ def test_pipeline_get_context_applies_dls_filter_superadmin(
     allowed_roles = called_kwargs["filter"]["authorization"]["$in"]
     assert "superadmin" in allowed_roles
     assert "dean_academic" in allowed_roles
+
+
+@patch("pipeline.retrieval.query_rewriter.QueryRewriter", MagicMock)
+@patch("pipeline.retrieval.retrieval_pipeline.Reranker")
+@patch("pipeline.retrieval.retrieval_pipeline.QueryPlanner")
+@patch("pipeline.retrieval.retrieval_pipeline.Retriever")
+def test_entityless_query_runs_full_query_bm25(
+    mock_retriever_class, _mock_planner, _mock_reranker
+):
+    """Regression: a keyword query that yields no planner entity must still get
+    a lexical (BM25) pass on the RAW query, folded into the retrieval pool. Before
+    the fix, BM25 only ran per-entity, so entity-less queries ("what are the
+    hostel rules", "course policy of EL470") degraded to pure dense search and
+    buried the exact document."""
+    pipeline, mock_retriever = _build_mocked_pipeline(mock_retriever_class)
+    mock_retriever.bm25.retrieve.return_value = [
+        {"id": "hostel-1", "score": 1.0, "metadata": {"title": "Hostel Rules"}}
+    ]
+
+    pipeline.get_context("what are the hostel rules", user_role="student")
+
+    # BM25 was invoked on the full raw query (no entities extracted here) …
+    mock_retriever.bm25.retrieve.assert_called()
+    _args, kwargs = mock_retriever.bm25.retrieve.call_args
+    assert kwargs["query"] == "what are the hostel rules"
+    # … and the same role/scope gating is applied so security is never bypassed.
+    lexical_filter = kwargs["metadata_filter"]
+    assert sorted(lexical_filter["authorization"]["$in"]) == sorted(["public", "student"])


### PR DESCRIPTION
Root cause: in _retrieve_dual_path the lexical (BM25) path only ran for planner-extracted entities — BM25 was invoked solely inside the per-entity loop via retriever.retrieve(ent_text). A query with strong keyword signal but no high-confidence entity ("what are the hostel rules", "course policy of EL470") reached the entity pool empty, so the 50/50 fusion collapsed to pure dense search. Dense-only then buried the exact document under near-duplicate chunks (e.g. 5+ "Hostel Management Committee" chunks ahead of the actual "Hostel Rules and Regulations" doc), and the top_k cut dropped it — matching the reported "can't retrieve course policy / hostel rules". Verified against the live corpus: a full-query BM25 pass ranks the correct doc #1 for both queries.

Fix: after the per-entity loop, run BM25 on the raw query and fold the hits into the same RRF pool, applying the identical authorization + academic scope filter so role/scope gating is never bypassed. Behaviour is unchanged when entities already populate the pool; entity-less queries now regain the lexical half of hybrid retrieval. Access is guarded so a retriever without a BM25 index degrades gracefully, like the semantic path does for a missing vector index.