### PR TITLE
fix(ai): ungate course docs from enrollment in signed-in retrieval

### DIFF
--- a/server/api/request_context.py
+++ b/server/api/request_context.py
@@ -67,15 +67,13 @@ class AcademicScope:
             return False
 
         if scope == "course":
-            # Course-policy documents are keyed by course_code enrollment,
-            # not programme identity — the same course is routinely taken by
-            # students from several programmes (electives, cross-listed
-            # courses), so it must not be required to match programme_id,
-            # degree_level, or admission_year fields that course-policy docs
-            # never carry in the first place.
-            course_code = metadata.get("course_code")
-            if course_code and course_code not in self.registered_course_codes:
-                return False
+            # Course documents (structure, catalog, per-course policy) are
+            # public course-catalog information, not enrollment-private data:
+            # a student must be able to look up any course they are considering
+            # or cross-listing, exactly as a signed-out guest already can. They
+            # are therefore not gated by registered_course_codes, and — being
+            # keyed by course_code rather than programme identity — must not be
+            # forced to match programme_id/degree_level/admission_year either.
             return True
 
         if metadata.get("programme_id") != self.programme_id:

--- a/server/rag/pipeline/retrieval/retrieval_pipeline.py
+++ b/server/rag/pipeline/retrieval/retrieval_pipeline.py
@@ -405,22 +405,20 @@ class RetrievalPipeline:
                 {"admission_year_to": {"$gte": academic_scope.admission_year}},
             ]
         }
-        # Course-policy documents are keyed by course_code, not by
-        # programme_id/degree_level/admission_year (they never populate those
-        # fields — the same course is often shared across programmes). They
-        # need their own clause instead of being forced through the
-        # programme/curriculum clause above, which they can never satisfy.
+        # Course documents (structure, catalog, per-course policy) are public
+        # course-catalog information: a signed-in student may look up any
+        # course, exactly as a signed-out guest can, so they are admitted
+        # unconditionally rather than gated by registered_course_codes. They
+        # are keyed by course_code, not by programme_id/degree_level/
+        # admission_year (they never populate those fields — the same course is
+        # often shared across programmes), so they need their own clause
+        # instead of being forced through the programme/curriculum clause
+        # above, which they can never satisfy.
         or_clauses = [
             {"applicability_scope": {"$eq": "global"}},
+            {"applicability_scope": {"$eq": "course"}},
             scoped,
         ]
-        if academic_scope.registered_course_codes:
-            or_clauses.append({
-                "$and": [
-                    {"applicability_scope": {"$eq": "course"}},
-                    {"course_code": {"$in": list(academic_scope.registered_course_codes)}},
-                ]
-            })
         # A missing branch on a document means programme-wide applicability;
         # branch equality is enforced by the post-retrieval predicate when a
         # document declares one, without excluding those programme-wide docs.

--- a/server/rag/pipeline/tests/test_academic_scope.py
+++ b/server/rag/pipeline/tests/test_academic_scope.py
@@ -63,7 +63,7 @@ def test_scope_rejects_other_programme_and_unclassified_academic_documents():
     assert not academic_scope.document_is_eligible({"applicability_scope": "unclassified"})
 
 
-def test_scope_rejects_out_of_range_and_unregistered_course():
+def test_scope_rejects_out_of_range_curriculum():
     academic_scope = scope()
     assert not academic_scope.document_is_eligible({
         "applicability_scope": "curriculum",
@@ -72,7 +72,13 @@ def test_scope_rejects_out_of_range_and_unregistered_course():
         "admission_year_from": 2025,
         "admission_year_to": 9999,
     })
-    assert not academic_scope.document_is_eligible({
+
+
+def test_scope_allows_course_docs_regardless_of_enrollment():
+    # Course docs are public course-catalog information: a signed-in student
+    # may look up any course, even one they are not registered for.
+    academic_scope = scope()
+    assert academic_scope.document_is_eligible({
         "applicability_scope": "course",
         "programme_id": "btech-ict",
         "degree_level": "undergraduate",

--- a/server/rag/pipeline/tests/test_qdrant_filter_translation.py
+++ b/server/rag/pipeline/tests/test_qdrant_filter_translation.py
@@ -136,4 +136,7 @@ def test_student_semantic_path_filter_carries_scope_end_to_end():
     assert "authorization" in blob
     assert "applicability_scope" in blob  # scope survived translation
     assert "programme_id" in blob
-    assert "course_code" in blob
+    # Course docs are admitted unconditionally now (no registered-course gate),
+    # so the scope $or carries a bare applicability_scope == "course" value
+    # rather than a course_code filter.
+    assert "course" in blob


### PR DESCRIPTION
## Summary

Course lookups (e.g. *"give course structure of IT227"*) returned the correct, detailed answer **only in guest / signed-out mode**. When signed in as a student, the same query fell back to a generic programme-curriculum answer (the "IC / PC / PE / FE…" structure) and claimed the specific course wasn't found.

The cause is the **academic-scope (RBAC) eligibility gate**, not query parsing (the hyphen `IT-227` vs `IT227` was a red herring).

## Root cause

At ingestion, any academics document carrying a `course_code` is tagged `applicability_scope: "course"` (`metadata_extractors.py:265`). That scope was **enrollment-gated, but only when signed in** — for a guest, `academic_scope is None`, so the gate is skipped entirely.

A signed-in student therefore only saw a course document if registered for that exact course, enforced at **two** layers:

| Layer | Location | Old behaviour |
|-------|----------|---------------|
| Pre-retrieval Qdrant filter | `retrieval_pipeline.py` · `_academic_scope_filter` | course docs admitted only if `course_code ∈ registered_course_codes` |
| Post-retrieval predicate | `request_context.py` · `AcademicScope.document_is_eligible` | dropped course docs where `course_code not in registered_course_codes` |

Both feed the entity-retriever path (`entity_retriever.py:161`) as well, so a course a student wasn't enrolled in was invisible to them — while a guest (no scope) saw it fine.

## Fix

Treat course documents as **public course-catalog information for everyone**. Admit `applicability_scope == "course"` unconditionally in both the pre- and post-retrieval gates, matching the existing guest behaviour.

- `server/api/request_context.py` — `document_is_eligible` returns `True` for `scope == "course"` regardless of enrollment.
- `server/rag/pipeline/retrieval/retrieval_pipeline.py` — `_academic_scope_filter` adds a bare `applicability_scope == "course"` clause and drops the `registered_course_codes` `$in` restriction.

`registered_course_codes` remains populated on `AcademicScope` — it's still used by other paths ("my courses" / timetable), so nothing else is affected.

### Tradeoff

This also un-gates genuine per-course **policy** docs (e.g. a specific course's grading/attendance policy) for non-enrolled students. That was the deliberate choice of "ungate all course docs" over the more surgical alternatives (named-course bypass, or splitting catalog-vs-policy metadata). If per-course policy needs to stay enrollment-private, follow up with a catalog-vs-policy metadata split at ingestion.

## Test plan

- Updated `test_academic_scope.py`: the old `test_scope_rejects_out_of_range_and_unregistered_course` is split into a curriculum out-of-range check plus a new positive `test_scope_allows_course_docs_regardless_of_enrollment`.
- Updated `test_qdrant_filter_translation.py`: removed the obsolete `course_code`-in-filter assertion; now asserts the bare `course` scope clause survives translation.
- `python -m pytest` across the scope / RBAC / ingestion suites (`test_academic_scope`, `test_qdrant_filter_translation`, `test_ict_cs_scope`, `test_elective_and_cohort_scoping`, `test_ecampus_scope_propagation`, `test_access_gate`, `test_ingestion_metadata`) → **107 passed**, no new failures.

## Ownership note

Changes span **Backend/Infra** (`request_context.py`) and **AI** (`retrieval_pipeline.py`) — per the repo's cross-domain rule, a review from both owning teams is appropriate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)