### PR TITLE
feat(ai): disclose source data period in answers

### DIFF
--- a/server/rag/pipeline/generation/answer_generator.py
+++ b/server/rag/pipeline/generation/answer_generator.py
@@ -193,6 +193,15 @@ _PARTIAL_TAIL_RE = re.compile(r"(?:\s*\[[\d\s,]*|\s+)$")
 # Matches the consolidated marker both generation paths append — the buffered
 # path via _clean_citations(), the streaming path via _StreamSanitizer.
 _SOURCES_MARKER_RE = re.compile(r"\[Sources:\s*([\d\s,]+)\]")
+_DOC_OPEN_TAG_RE = re.compile(r"<doc\b(?P<attrs>.*?)>", re.DOTALL | re.IGNORECASE)
+_DOC_DATE_ATTRIBUTE_RE = re.compile(
+    r'\b(?P<name>id|rule_year|scraped_date)="(?P<value>[^"]*)"',
+    re.IGNORECASE,
+)
+_ACADEMIC_YEAR_RE = re.compile(
+    r"(?<!\d)(?P<start>(?:20)?\d{2})\s*[-\u2013]\s*(?P<end>(?:20)?\d{2})(?!\d)"
+)
+_CALENDAR_DATE_RE = re.compile(r"(?<!\d)(20\d{2}(?:-\d{2}(?:-\d{2})?)?)(?!\d)")
 
 
 def extract_cited_ids(answer: str) -> set[int]:
@@ -212,6 +221,113 @@ def extract_cited_ids(answer: str) -> set[int]:
         for m in _SOURCES_MARKER_RE.finditer(answer)
         for n in re.findall(r"\d+", m.group(1))
     }
+
+
+def _extract_inline_cited_ids(answer: str) -> set[int]:
+    return {
+        int(n)
+        for marker in _CITATION_RE.finditer(answer or "")
+        for n in re.findall(r"\d+", marker.group(0))
+    }
+
+
+def _normalize_academic_year(value: str) -> str | None:
+    match = _ACADEMIC_YEAR_RE.search(value or "")
+    if not match:
+        return None
+
+    start_raw = match.group("start")
+    end_raw = match.group("end")
+    start = int(start_raw) if len(start_raw) == 4 else 2000 + int(start_raw)
+    if len(end_raw) == 4:
+        end = int(end_raw)
+    else:
+        end = (start // 100) * 100 + int(end_raw)
+        if end < start:
+            end += 100
+
+    if end != start + 1:
+        return None
+    return f"{start:04d}-{end:04d}"
+
+
+def _document_date_metadata(context: str) -> dict[int, tuple[str, str]]:
+    documents = {}
+    for doc_match in _DOC_OPEN_TAG_RE.finditer(context or ""):
+        attrs = {
+            match.group("name").lower(): match.group("value").strip()
+            for match in _DOC_DATE_ATTRIBUTE_RE.finditer(doc_match.group("attrs"))
+        }
+        try:
+            doc_id = int(attrs.get("id", ""))
+        except ValueError:
+            continue
+        documents[doc_id] = (
+            attrs.get("rule_year", ""),
+            attrs.get("scraped_date", ""),
+        )
+    return documents
+
+
+def build_data_period_note(context: str, cited_ids: set[int]) -> str:
+    """Describe the currency of the source documents actually used."""
+    metadata = _document_date_metadata(context)
+    academic_years = []
+    fetched_dates = []
+    undated = False
+
+    for doc_id in sorted(cited_ids):
+        rule_year, scraped_date = metadata.get(doc_id, ("", ""))
+        academic_year = _normalize_academic_year(rule_year)
+        if academic_year:
+            if academic_year not in academic_years:
+                academic_years.append(academic_year)
+            continue
+
+        fetched_match = _CALENDAR_DATE_RE.search(scraped_date)
+        if fetched_match:
+            fetched_date = fetched_match.group(1)
+            if fetched_date not in fetched_dates:
+                fetched_dates.append(fetched_date)
+            continue
+
+        year_match = _CALENDAR_DATE_RE.search(rule_year)
+        if year_match:
+            year = year_match.group(1)
+            if year not in fetched_dates:
+                fetched_dates.append(year)
+            continue
+
+        undated = True
+
+    if not cited_ids:
+        return "Data period: No dated source was cited for this response."
+
+    parts = []
+    if academic_years:
+        label = "Academic Year" if len(academic_years) == 1 else "Academic Years"
+        parts.append(f"{label} {', '.join(academic_years)}")
+    if fetched_dates:
+        label = "source fetched as of" if len(fetched_dates) == 1 else "sources fetched as of"
+        parts.append(f"{label} {', '.join(fetched_dates)}")
+
+    if not parts:
+        return "Data period: The cited source does not specify a date."
+
+    note = f"Data period: {'; '.join(parts)}."
+    if undated:
+        note += " Some cited sources do not specify a date."
+    return note
+
+
+def append_data_period_note(answer: str, context: str, cited_ids: set[int]) -> str:
+    note = build_data_period_note(context, cited_ids)
+    marker = _SOURCES_MARKER_RE.search(answer or "")
+    if marker:
+        body = answer[:marker.start()].rstrip()
+        sources = answer[marker.start():]
+        return f"{body}\n\n{note}\n\n{sources}"
+    return f"{(answer or '').rstrip()}\n\n{note}".lstrip()
 
 
 def filter_sources_by_citations(sources, citation_map, answer):
@@ -402,6 +518,7 @@ If the question is primarily outside DAU's scope, do not answer it using retriev
 
 - Professional, warm, concise. Paragraphs by default; bullets for lists/steps/requirements/comparisons.
 - Ground factual policy with academic/rule year; if docs span years, structure by year.
+- Always disclose source currency: use `rule_year` as the academic year when present; otherwise use `scraped_date` as the fetch date. Never present `scraped_date` as an academic year, and say when a cited source is undated.
 - Citations `[1]` or `[1][3]` right after the supported sentence. No citations on greetings/clarifying/conversational text. Integrate — do not quote long passages.
 - Partial coverage: answer what is supported, then state what is missing.
 - No coverage: "I could not find that information in the available university data." Name the responsible office if identified; point to https://www.daiict.ac.in.
@@ -639,6 +756,7 @@ Retrieved Documents
                     dispatch=dispatch, max_tokens=answer_max_tokens,
                     on_profile_update=on_profile_update,
                     profile_erp_id=profile_erp_id,
+                    context=context,
                 )
 
             # The router picks the node internally and does not report which one
@@ -699,7 +817,9 @@ Retrieved Documents
                 if "```" in answer or not is_grounded:
                     return out_of_scope_response
 
-            return self._clean_citations(answer)
+            cited_ids = _extract_inline_cited_ids(answer)
+            cleaned_answer = self._clean_citations(answer)
+            return append_data_period_note(cleaned_answer, context, cited_ids)
 
         except ContextLengthExceeded as e:
             log_soft_failure(
@@ -806,6 +926,7 @@ Retrieved Documents
         max_tokens=None,
         on_profile_update=None,
         profile_erp_id=None,
+        context="",
     ):
         stream_messages = [{"role": "system", "content": system_prompt}]
         if history:
@@ -918,6 +1039,7 @@ Retrieved Documents
             if delta:
                 _emit(sanitizer.feed(delta))
         _emit(sanitizer.flush())
+        _emit("\n\n" + build_data_period_note(context, sanitizer.cited))
         _emit(sanitizer.sources_tail())
 
         return "".join(emitted)

--- a/server/rag/pipeline/tests/test_answer_data_period.py
+++ b/server/rag/pipeline/tests/test_answer_data_period.py
@@ -1,0 +1,114 @@
+"""Source-date disclosure for generated AURA answers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from pipeline.generation.answer_generator import (
+    AnswerGenerator,
+    build_data_period_note,
+)
+
+
+def _context(*docs: str) -> str:
+    return "<context>\n" + "\n".join(docs) + "\n</context>"
+
+
+def _doc(doc_id: int, rule_year: str = "", scraped_date: str = "") -> str:
+    return (
+        f'<doc id="{doc_id}" rule_year="{rule_year}" '
+        f'scraped_date="{scraped_date}">evidence</doc>'
+    )
+
+
+def test_academic_year_is_expanded_to_four_digit_range():
+    context = _context(_doc(1, rule_year="2025-26", scraped_date="2026-07-01"))
+    assert build_data_period_note(context, {1}) == (
+        "Data period: Academic Year 2025-2026."
+    )
+
+
+def test_scraped_date_is_used_only_when_academic_year_is_missing():
+    context = _context(_doc(1, scraped_date="2024-11-03"))
+    assert build_data_period_note(context, {1}) == (
+        "Data period: source fetched as of 2024-11-03."
+    )
+
+
+def test_multiple_cited_academic_years_are_disclosed():
+    context = _context(
+        _doc(1, rule_year="24-25"),
+        _doc(2, rule_year="2025-2026"),
+    )
+    assert build_data_period_note(context, {1, 2}) == (
+        "Data period: Academic Years 2024-2025, 2025-2026."
+    )
+
+
+def test_undated_cited_source_is_disclosed():
+    context = _context(_doc(1))
+    assert build_data_period_note(context, {1}) == (
+        "Data period: The cited source does not specify a date."
+    )
+
+
+def test_buffered_generation_appends_period_before_sources():
+    response = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="The fee is listed. [1]"))]
+    )
+    context = _context(_doc(1, rule_year="2025-26"))
+    generator = AnswerGenerator()
+
+    with patch.object(generator, "_budget_max_tokens", return_value=256), patch(
+        "pipeline.generation.answer_generator.InferenceRouter.call_with_rotation",
+        return_value=response,
+    ):
+        answer = generator.generate(
+            query="What is the fee?",
+            context=context,
+            plan={"retrieval_intent": "general", "entities": {}},
+        )
+
+    assert answer == (
+        "The fee is listed.\n\n"
+        "Data period: Academic Year 2025-2026.\n\n"
+        "[Sources: 1]"
+    )
+
+
+def test_streaming_generation_appends_period_before_sources():
+    stream = [
+        SimpleNamespace(
+            choices=[SimpleNamespace(delta=SimpleNamespace(content="The fee is listed. [1]"))]
+        )
+    ]
+    context = _context(_doc(1, rule_year="2025-26"))
+    generator = AnswerGenerator()
+    emitted = []
+
+    with patch(
+        "pipeline.generation.answer_generator.InferenceRouter.call_with_rotation",
+        return_value=stream,
+    ):
+        answer = generator._generate_streaming(
+            system_prompt="system",
+            user_prompt="question",
+            on_delta=emitted.append,
+            max_tokens=256,
+            context=context,
+        )
+
+    expected = (
+        "The fee is listed.\n\n"
+        "Data period: Academic Year 2025-2026.\n\n"
+        "[Sources: 1]"
+    )
+    assert answer == expected
+    assert "".join(emitted) == expected


### PR DESCRIPTION
## Summary

- Add a Data period footer to generated answers so users can see which academic year or fetch date supports the response.
- Normalize rule years like 2025-26 into 2025-2026, and fall back to scraped_date when rule-year metadata is missing.
- Cover both buffered and streaming answer generation paths with focused backend tests.

## Impact

Chatbot answers now make source currency explicit, reducing confusion when retrieved DAU data is older or spans multiple academic years.

## Validation

- server/.venv/Scripts/python.exe -B -m pytest server/rag/pipeline/tests/test_answer_data_period.py server/rag/pipeline/tests/test_answer_generator.py -q - 23 passed
- Earlier implementation checks: pnpm type-check passed; pnpm lint reported 0 errors and 3 unrelated warnings