### PR TITLE
fix(retrieval): widen Stage-1 reranker cutoff from top 12 to top 18 candidates

### DIFF
--- a/server/rag/pipeline/retrieval/retrieval_pipeline.py
+++ b/server/rag/pipeline/retrieval/retrieval_pipeline.py
@@ -1167,16 +1167,16 @@ class RetrievalPipeline:
             )
             _log_candidates("AFTER STAGE-1 RERANK", stage1_reranked)
             
-            # Select top 12 candidates
-            top_candidates = stage1_reranked[:12]
+            # Select top 18 candidates
+            top_candidates = stage1_reranked[:18]
             
-            # Expand only the top 12 candidates
+            # Expand only the top 18 candidates
             expand_window = 2 if retrieval_intent == "policy_version" else 1
             expanded_candidates = self._eligible_results(
                 self._expand_adjacent_chunks(top_candidates, window=expand_window), academic_scope
             )
             
-            # Stage 2: Final precise rerank on expanded top 12 chunks
+            # Stage 2: Final precise rerank on expanded top 18 chunks
             reranked = self.reranker.rerank(
                 query=query,
                 results=expanded_candidates,


### PR DESCRIPTION
## Summary
This PR widens the Stage-1 cross-encoder reranker cutoff from top 12 () to top 18 () candidates in  to alleviate the recall bottleneck prior to adjacent chunk expansion and Stage-2 precision reranking.

## Changes Made
- Widened Stage-1 reranker candidate selection cutoff from  to  in .
- Preserved all other pipeline components, retrieval logic, entity retrieval, BM25, Qdrant top_k, scoring weights, context builder token limits, and Stage-2 dynamic final top_k logic.

## Verification
- Synced cleanly with  with zero merge conflicts.
- Verified single-file modification with 4 insertions and 4 deletions.