### PR TITLE
Fix vLLM served model default

### DIFF
--- a/.github/deploy/.env.prod.example
+++ b/.github/deploy/.env.prod.example
@@ -48,6 +48,7 @@ VLLM_ENDPOINTS=http://vllm-node1:8000/v1,http://vllm-node2:8000/v1,http://vllm-n
 # Must match the served id from GET /v1/models (live cluster often uses aura-llm
 # via --served-model-name, not the HuggingFace repo id).
 VLLM_MODEL=aura-llm
+VLLM_MODEL_PATH=Qwen/Qwen3-32B-AWQ
 VLLM_API_KEY=EMPTY
 
 # vLLM scheduler ceiling (GPU-08). Consumed by docker-compose as

--- a/.github/deploy/docker-compose.prod.yml
+++ b/.github/deploy/docker-compose.prod.yml
@@ -88,7 +88,7 @@ services:
       INTERNAL_RESOLVE_SECRET: ${INTERNAL_RESOLVE_SECRET}
       # Override in .env.prod for multi-host GPU IPs / single-node pools.
       VLLM_ENDPOINTS: ${VLLM_ENDPOINTS:-http://vllm-node1:8000/v1,http://vllm-node2:8000/v1,http://vllm-node3:8000/v1}
-      VLLM_MODEL: ${VLLM_MODEL:-Qwen/Qwen3-32B-AWQ}
+      VLLM_MODEL: ${VLLM_MODEL:-aura-llm}
       VLLM_API_KEY: ${VLLM_API_KEY:-EMPTY}
       QDRANT_URL: ${QDRANT_URL:-http://qdrant:6333}
       QDRANT_API_KEY: ${QDRANT_API_KEY:-}
@@ -193,7 +193,7 @@ services:
     image: vllm/vllm-openai:latest
     profiles: ["gpu"]
     restart: unless-stopped
-    command: ["--model", "${VLLM_MODEL:-Qwen/Qwen3-32B-AWQ}", "--port", "8000", "--enable-prefix-caching", "--max-model-len", "${MAX_MODEL_LEN:-16384}", "--max-num-seqs", "${VLLM_MAX_NUM_SEQS:-24}"]
+    command: ["--model", "${VLLM_MODEL_PATH:-Qwen/Qwen3-32B-AWQ}", "--served-model-name", "${VLLM_MODEL:-aura-llm}", "--port", "8000", "--enable-prefix-caching", "--max-model-len", "${MAX_MODEL_LEN:-16384}", "--max-num-seqs", "${VLLM_MAX_NUM_SEQS:-24}"]
     expose:
       - "8000"
     volumes:
@@ -224,7 +224,7 @@ services:
     image: vllm/vllm-openai:latest
     profiles: ["gpu"]
     restart: unless-stopped
-    command: ["--model", "${VLLM_MODEL:-Qwen/Qwen3-32B-AWQ}", "--port", "8000", "--enable-prefix-caching", "--max-model-len", "${MAX_MODEL_LEN:-16384}", "--max-num-seqs", "${VLLM_MAX_NUM_SEQS:-24}"]
+    command: ["--model", "${VLLM_MODEL_PATH:-Qwen/Qwen3-32B-AWQ}", "--served-model-name", "${VLLM_MODEL:-aura-llm}", "--port", "8000", "--enable-prefix-caching", "--max-model-len", "${MAX_MODEL_LEN:-16384}", "--max-num-seqs", "${VLLM_MAX_NUM_SEQS:-24}"]
     expose:
       - "8000"
     volumes:
@@ -255,7 +255,7 @@ services:
     image: vllm/vllm-openai:latest
     profiles: ["gpu"]
     restart: unless-stopped
-    command: ["--model", "${VLLM_MODEL:-Qwen/Qwen3-32B-AWQ}", "--port", "8000", "--enable-prefix-caching", "--max-model-len", "${MAX_MODEL_LEN:-16384}", "--max-num-seqs", "${VLLM_MAX_NUM_SEQS:-24}"]
+    command: ["--model", "${VLLM_MODEL_PATH:-Qwen/Qwen3-32B-AWQ}", "--served-model-name", "${VLLM_MODEL:-aura-llm}", "--port", "8000", "--enable-prefix-caching", "--max-model-len", "${MAX_MODEL_LEN:-16384}", "--max-num-seqs", "${VLLM_MAX_NUM_SEQS:-24}"]
     expose:
       - "8000"
     volumes:

--- a/.github/deploy/node1/.env.node1.example
+++ b/.github/deploy/node1/.env.node1.example
@@ -54,6 +54,7 @@ VLLM_ENDPOINTS=http://<NODE_1_IP>:8001/v1,http://<NODE_2_IP>:8000/v1,http://<NOD
 # one over the other.
 # Must match the served model id from GET /v1/models (e.g. aura-llm).
 VLLM_MODEL=aura-llm
+VLLM_MODEL_PATH=Qwen/Qwen3-32B-AWQ
 VLLM_API_KEY=EMPTY
 
 # vLLM scheduler ceiling (GPU-08). Consumed by docker-compose as

--- a/.github/deploy/node1/docker-compose.yml
+++ b/.github/deploy/node1/docker-compose.yml
@@ -113,7 +113,7 @@ services:
       INTERNAL_RESOLVE_SECRET: ${INTERNAL_RESOLVE_SECRET}
       # Override in .env.prod for multi-host GPU IPs / single-node pools.
       VLLM_ENDPOINTS: ${VLLM_ENDPOINTS:-http://vllm-node1:8000/v1,http://vllm-node2:8000/v1,http://vllm-node3:8000/v1}
-      VLLM_MODEL: ${VLLM_MODEL:-Qwen/Qwen3-32B-AWQ}
+      VLLM_MODEL: ${VLLM_MODEL:-aura-llm}
       VLLM_API_KEY: ${VLLM_API_KEY:-EMPTY}
       QDRANT_URL: ${QDRANT_URL:-http://qdrant:6333}
       QDRANT_API_KEY: ${QDRANT_API_KEY:-}
@@ -232,7 +232,7 @@ services:
     image: vllm/vllm-openai:latest
     profiles: [ "gpu" ]
     restart: unless-stopped
-    command: [ "--model", "${VLLM_MODEL:-Qwen/Qwen3-32B-AWQ}", "--port", "8000", "--enable-prefix-caching", "--max-model-len", "${MAX_MODEL_LEN:-16384}", "--gpu-memory-utilization", "${VLLM_GPU_MEM_UTIL:-0.92}", "--max-num-seqs", "${VLLM_MAX_NUM_SEQS:-24}" ]
+    command: [ "--model", "${VLLM_MODEL_PATH:-Qwen/Qwen3-32B-AWQ}", "--served-model-name", "${VLLM_MODEL:-aura-llm}", "--port", "8000", "--enable-prefix-caching", "--max-model-len", "${MAX_MODEL_LEN:-16384}", "--gpu-memory-utilization", "${VLLM_GPU_MEM_UTIL:-0.92}", "--max-num-seqs", "${VLLM_MAX_NUM_SEQS:-24}" ]
     expose:
       - "8000"
     volumes:
@@ -257,7 +257,7 @@ services:
     image: vllm/vllm-openai:latest
     profiles: [ "gpu" ]
     restart: unless-stopped
-    command: [ "--model", "${VLLM_MODEL:-Qwen/Qwen3-32B-AWQ}", "--port", "8000", "--enable-prefix-caching", "--max-model-len", "${MAX_MODEL_LEN:-16384}", "--gpu-memory-utilization", "${VLLM_GPU_MEM_UTIL:-0.92}", "--max-num-seqs", "${VLLM_MAX_NUM_SEQS:-24}" ]
+    command: [ "--model", "${VLLM_MODEL_PATH:-Qwen/Qwen3-32B-AWQ}", "--served-model-name", "${VLLM_MODEL:-aura-llm}", "--port", "8000", "--enable-prefix-caching", "--max-model-len", "${MAX_MODEL_LEN:-16384}", "--gpu-memory-utilization", "${VLLM_GPU_MEM_UTIL:-0.92}", "--max-num-seqs", "${VLLM_MAX_NUM_SEQS:-24}" ]
     expose:
       - "8000"
     volumes:
@@ -282,7 +282,7 @@ services:
     image: vllm/vllm-openai:latest
     profiles: [ "gpu" ]
     restart: unless-stopped
-    command: [ "--model", "${VLLM_MODEL:-Qwen/Qwen3-32B-AWQ}", "--port", "8000", "--enable-prefix-caching", "--max-model-len", "${MAX_MODEL_LEN:-16384}", "--gpu-memory-utilization", "${VLLM_GPU_MEM_UTIL:-0.92}", "--max-num-seqs", "${VLLM_MAX_NUM_SEQS:-24}" ]
+    command: [ "--model", "${VLLM_MODEL_PATH:-Qwen/Qwen3-32B-AWQ}", "--served-model-name", "${VLLM_MODEL:-aura-llm}", "--port", "8000", "--enable-prefix-caching", "--max-model-len", "${MAX_MODEL_LEN:-16384}", "--gpu-memory-utilization", "${VLLM_GPU_MEM_UTIL:-0.92}", "--max-num-seqs", "${VLLM_MAX_NUM_SEQS:-24}" ]
     expose:
       - "8000"
     volumes:

--- a/.github/deploy/node2/.env.node2.example
+++ b/.github/deploy/node2/.env.node2.example
@@ -1,4 +1,5 @@
 # Node 2 (vLLM Node 1) Environment Configuration
-VLLM_MODEL=Qwen/Qwen3-32B-AWQ
+VLLM_MODEL=aura-llm
+VLLM_MODEL_PATH=Qwen/Qwen3-32B-AWQ
 MAX_MODEL_LEN=8192
 HUGGING_FACE_HUB_TOKEN=

--- a/.github/deploy/node2/docker-compose.yml
+++ b/.github/deploy/node2/docker-compose.yml
@@ -21,7 +21,8 @@ services:
     image: vllm/vllm-openai:latest
     restart: unless-stopped
     command: [
-      "--model", "${VLLM_MODEL:-Qwen/Qwen3-32B-AWQ}",
+      "--model", "${VLLM_MODEL_PATH:-Qwen/Qwen3-32B-AWQ}",
+      "--served-model-name", "${VLLM_MODEL:-aura-llm}",
       "--port", "8000",
       "--host", "0.0.0.0",
       "--enable-prefix-caching",

--- a/.github/deploy/node3/.env.node3.example
+++ b/.github/deploy/node3/.env.node3.example
@@ -1,4 +1,5 @@
 # Node 3 (vLLM Node 2) Environment Configuration
-VLLM_MODEL=Qwen/Qwen3-32B-AWQ
+VLLM_MODEL=aura-llm
+VLLM_MODEL_PATH=Qwen/Qwen3-32B-AWQ
 MAX_MODEL_LEN=8192
 HUGGING_FACE_HUB_TOKEN=

--- a/.github/deploy/node3/docker-compose.yml
+++ b/.github/deploy/node3/docker-compose.yml
@@ -13,7 +13,7 @@ services:
   vllm-node2:
     image: vllm/vllm-openai:latest
     restart: unless-stopped
-    command: [ "--model", "${VLLM_MODEL:-Qwen/Qwen3-32B-AWQ}", "--port", "8000", "--host", "0.0.0.0", "--enable-prefix-caching", "--max-model-len", "${MAX_MODEL_LEN:-16384}", "--gpu-memory-utilization", "${VLLM_GPU_MEM_UTIL:-0.92}", "--max-num-seqs", "${VLLM_MAX_NUM_SEQS:-24}" ]
+    command: [ "--model", "${VLLM_MODEL_PATH:-Qwen/Qwen3-32B-AWQ}", "--served-model-name", "${VLLM_MODEL:-aura-llm}", "--port", "8000", "--host", "0.0.0.0", "--enable-prefix-caching", "--max-model-len", "${MAX_MODEL_LEN:-16384}", "--gpu-memory-utilization", "${VLLM_GPU_MEM_UTIL:-0.92}", "--max-num-seqs", "${VLLM_MAX_NUM_SEQS:-24}" ]
     ports:
       - "8000:8000"
     volumes:

--- a/docs/live-chatbot-test-report-2026-08-03.md
+++ b/docs/live-chatbot-test-report-2026-08-03.md
@@ -1,0 +1,68 @@
+# DAU PWA Live Chatbot Test Report
+
+- Run time: 2026-08-03 18:14:46 India Standard Time
+- Target: live Node 1 HTTPS deployment
+- Health: HTTP 200, `{"status":"online","service":"AURA API"}`
+- Mode: website guest path via `/api/chat`
+- Scope requested: Academics & Curriculum (~60), Course Policies (~50)
+- Scope executed in this run: 10 guest smoke questions because anonymous website quota is 10/day
+
+## Summary
+
+- PASS: 0
+- REVIEW: 10
+- FAIL: 0
+- BLOCKED: 0
+
+All 10 live website requests returned HTTP 200, but every answer returned the generic backend generation error:
+
+```text
+Sorry, I encountered an error while generating a response. Please try again.
+```
+
+## Where it goes wrong
+
+The live vLLM APIs expose the served model id `aura-llm` from `/v1/models`.
+The deployment/backend defaults were still using the HuggingFace model path `Qwen/Qwen3-32B-AWQ` as the request model id in several places.
+
+That creates this failure path:
+
+1. Website sends the user question to `/api/chat`.
+2. Backend reaches retrieval/generation.
+3. Backend asks the OpenAI-compatible vLLM API for model `Qwen/Qwen3-32B-AWQ`.
+4. Live vLLM only serves `aura-llm`.
+5. Generation fails and the website shows the generic error response.
+
+Fix applied in this branch: `VLLM_MODEL` now means the served model id (`aura-llm`), and `VLLM_MODEL_PATH` means the model weights path used when starting vLLM (`Qwen/Qwen3-32B-AWQ`).
+
+## Results
+
+| # | Category | Verdict | HTTP | Time | Question | Missing / Notes |
+|---:|---|---|---:|---:|---|---|
+| 1 | Academics & Curriculum | REVIEW | 200 | 27.78s | What undergraduate programmes are offered at DAU? | programme, B.Tech, Data period:, citations/sources |
+| 2 | Academics & Curriculum | REVIEW | 200 | 32.31s | What is the curriculum structure for B.Tech ICT? | ICT, curriculum, Data period:, citations/sources |
+| 3 | Academics & Curriculum | REVIEW | 200 | 41.86s | Which courses are listed for the first year B.Tech curriculum? | course, Data period:, citations/sources |
+| 4 | Academics & Curriculum | REVIEW | 200 | 32.21s | What are the credit requirements for B.Tech ICT? | credit, Data period:, citations/sources |
+| 5 | Academics & Curriculum | REVIEW | 200 | 26.76s | What electives are available in the Computational Science area? | elective, Computational, Data period:, citations/sources |
+| 6 | Course Policies | REVIEW | 200 | 4.20s | What is the attendance policy for DAU courses? | attendance, Data period:, citations/sources |
+| 7 | Course Policies | REVIEW | 200 | 4.42s | How is course grading handled at DAU? | grading, Data period:, citations/sources |
+| 8 | Course Policies | REVIEW | 200 | 4.57s | What are course outcomes and where are they mentioned in course policy documents? | outcome, Data period:, citations/sources |
+| 9 | Course Policies | REVIEW | 200 | 31.27s | What syllabus modules are listed for Introduction to ICT? | module, ICT, Data period:, citations/sources |
+| 10 | Course Policies | REVIEW | 200 | 27.95s | What does a DAU course policy usually include? | policy, Data period:, citations/sources |
+
+## Live endpoint checks
+
+- Node 1 HTTPS health route: HTTP 200
+- Node 1 backend health route: HTTP 200
+- vLLM node 1 `/v1/models`: served model `aura-llm`
+- vLLM node 2 `/v1/models`: served model `aura-llm`
+- vLLM node 3 `/v1/models`: served model `aura-llm`
+- Qdrant collections route: reachable, collection `aura_documents`
+
+## Blocker for full 110-question website run
+
+The public website guest route is intentionally limited to 10 questions/day.
+To run all ~110 questions through the deployed website, use either:
+
+- a signed-in DAU browser session, or
+- an explicitly approved dedicated server-side test identity.

--- a/server/rag/.env.example
+++ b/server/rag/.env.example
@@ -47,11 +47,13 @@ GOOGLE_CALENDAR_REDIRECT_URI=http://localhost:8000/calendar/callback
 
 # LLM Inference — self-hosted vLLM inference pool (architecture doc §13–16)
 # Comma-separated OpenAI-compatible base URLs, one per vLLM node
-# (e.g. "vllm serve Qwen/Qwen3-32B-AWQ --port 8000" on each GPU node).
+# (e.g. "vllm serve Qwen/Qwen3-32B-AWQ --served-model-name aura-llm --port 8000"
+# on each GPU node).
 # A single URL is fine too — InferenceRouter treats a 1-node pool the same
 # way, it just has nowhere to fail over to.
 VLLM_ENDPOINTS=http://vllm-node1:8000/v1,http://vllm-node2:8000/v1,http://vllm-node3:8000/v1
-VLLM_MODEL=Qwen/Qwen3-32B-AWQ
+# Must match the served model id returned by GET /v1/models.
+VLLM_MODEL=aura-llm
 # Most vLLM deployments don't check this, but the OpenAI client requires a
 # non-empty value.
 VLLM_API_KEY=EMPTY

--- a/server/rag/personal_query_classifier.py
+++ b/server/rag/personal_query_classifier.py
@@ -142,7 +142,7 @@ class PersonalQueryClassifier:
 
     def __init__(self):
         load_dotenv()
-        self.model = os.getenv("VLLM_MODEL", os.getenv("GROQ_MODEL", "Qwen/Qwen3-32B-AWQ"))
+        self.model = os.getenv("VLLM_MODEL", os.getenv("GROQ_MODEL", "aura-llm"))
 
     def classify(self, query: str, history: list = None) -> dict:
         if not query:

--- a/server/rag/pipeline/ecampus/intent_router.py
+++ b/server/rag/pipeline/ecampus/intent_router.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 class PersonalDataIntentRouter:
     def __init__(self):
         load_dotenv()
-        self.model = os.getenv("VLLM_MODEL", os.getenv("GROQ_MODEL", "Qwen/Qwen3-32B-AWQ"))
+        self.model = os.getenv("VLLM_MODEL", os.getenv("GROQ_MODEL", "aura-llm"))
         self.system_prompt = """
 Classify the user's query as PERSONAL_DATA, COMMUNITY, or GENERAL.
 

--- a/server/rag/pipeline/ecampus/orchestrator.py
+++ b/server/rag/pipeline/ecampus/orchestrator.py
@@ -388,7 +388,7 @@ def _required_calendar_tool(query: str, history: list[dict]) -> str | None:
 class EcampusOrchestrator:
     def __init__(self):
         load_dotenv()
-        self.model = os.getenv("VLLM_MODEL", os.getenv("GROQ_MODEL", "Qwen/Qwen3-32B-AWQ"))
+        self.model = os.getenv("VLLM_MODEL", os.getenv("GROQ_MODEL", "aura-llm"))
         # No self.client — every LLM call goes through InferenceRouter.call_with_rotation
         # so this orchestrator participates in key rotation just like every
         # other pipeline component.

--- a/server/rag/pipeline/ecampus/scholarship_tools.py
+++ b/server/rag/pipeline/ecampus/scholarship_tools.py
@@ -161,7 +161,7 @@ def screen_scholarship_eligibility(
 
     def _execute(client):
         return client.chat.completions.create(
-            model=os.getenv("VLLM_MODEL", os.getenv("GROQ_MODEL", "Qwen/Qwen3-32B-AWQ")),
+            model=os.getenv("VLLM_MODEL", os.getenv("GROQ_MODEL", "aura-llm")),
             temperature=0,
             messages=[
                 {"role": "system", "content": _SCHOLARSHIP_SYSTEM_PROMPT.strip()},

--- a/server/rag/pipeline/generation/answer_generator.py
+++ b/server/rag/pipeline/generation/answer_generator.py
@@ -583,7 +583,7 @@ class AnswerGenerator:
 
         self.model = os.getenv(
             "VLLM_MODEL",
-            os.getenv("GROQ_MODEL", "Qwen/Qwen3-32B-AWQ")
+            os.getenv("GROQ_MODEL", "aura-llm")
         )
 
     def generate(

--- a/server/rag/pipeline/guardrails/query_guardrail.py
+++ b/server/rag/pipeline/guardrails/query_guardrail.py
@@ -39,7 +39,7 @@ IMPLICIT_DAU_PAT = re.compile(
 class QueryGuardrail:
     def __init__(self):
         load_dotenv()
-        self.model = os.getenv("VLLM_MODEL", os.getenv("GROQ_MODEL", "Qwen/Qwen3-32B-AWQ"))
+        self.model = os.getenv("VLLM_MODEL", os.getenv("GROQ_MODEL", "aura-llm"))
         self.system_prompt = """
 You are the security and scope filter for AURA, the assistant for Dhirubhai
 Ambani University (DAU). Classify the user's query as SAFE, UNSAFE, or

--- a/server/rag/pipeline/guardrails/wellness_guardrail.py
+++ b/server/rag/pipeline/guardrails/wellness_guardrail.py
@@ -121,7 +121,7 @@ class WellnessGuardrail:
             "VLLM_WELLNESS_MODEL",
             os.getenv(
                 "GROQ_WELLNESS_MODEL",
-                os.getenv("VLLM_MODEL", "Qwen/Qwen3-32B-AWQ"),
+                os.getenv("VLLM_MODEL", "aura-llm"),
             ),
         )
 

--- a/server/rag/pipeline/inference_router.py
+++ b/server/rag/pipeline/inference_router.py
@@ -169,7 +169,7 @@ class InferenceRouter:
             cls._QUEUE_SCRAPE_TIMEOUT = _env_float("VLLM_QUEUE_SCRAPE_TIMEOUT", 1.0)
             cls._QUEUE_KV_SOFT = _env_float("VLLM_QUEUE_KV_SOFT", 0.85)
             cls._QUEUE_KV_PENALTY = _env_float("VLLM_QUEUE_KV_PENALTY", 8.0)
-            cls._model = os.getenv("VLLM_MODEL", "aura-llm")
+            cls._model = os.getenv("VLLM_MODEL") or os.getenv("GROQ_MODEL") or "aura-llm"
             cls._initialized = True
             print(f"[InferenceRouter] Initialized with {len(cls._nodes)} vLLM node(s): {cls._nodes} (model={cls._model})")
 

--- a/server/rag/pipeline/inference_router.py
+++ b/server/rag/pipeline/inference_router.py
@@ -169,7 +169,7 @@ class InferenceRouter:
             cls._QUEUE_SCRAPE_TIMEOUT = _env_float("VLLM_QUEUE_SCRAPE_TIMEOUT", 1.0)
             cls._QUEUE_KV_SOFT = _env_float("VLLM_QUEUE_KV_SOFT", 0.85)
             cls._QUEUE_KV_PENALTY = _env_float("VLLM_QUEUE_KV_PENALTY", 8.0)
-            cls._model = os.getenv("VLLM_MODEL", "Qwen/Qwen3-32B-AWQ")
+            cls._model = os.getenv("VLLM_MODEL", "aura-llm")
             cls._initialized = True
             print(f"[InferenceRouter] Initialized with {len(cls._nodes)} vLLM node(s): {cls._nodes} (model={cls._model})")
 

--- a/server/rag/pipeline/retrieval/query_planner.py
+++ b/server/rag/pipeline/retrieval/query_planner.py
@@ -1132,7 +1132,7 @@ class QueryPlanner:
 
         self.model = os.getenv(
             "VLLM_MODEL",
-            os.getenv("GROQ_MODEL", "Qwen/Qwen3-32B-AWQ")
+            os.getenv("GROQ_MODEL", "aura-llm")
         )
 
     def plan(self, query, academic_scope=None, history=None, identity=None):

--- a/server/rag/pipeline/retrieval/query_rewriter.py
+++ b/server/rag/pipeline/retrieval/query_rewriter.py
@@ -8,7 +8,7 @@ class QueryRewriter:
         load_dotenv()
         self.model = os.getenv(
             "VLLM_MODEL",
-            os.getenv("GROQ_MODEL", "Qwen/Qwen3-32B-AWQ")
+            os.getenv("GROQ_MODEL", "aura-llm")
         )
 
     def rewrite(

--- a/server/rag/pipeline/tests/test_inference_router.py
+++ b/server/rag/pipeline/tests/test_inference_router.py
@@ -54,6 +54,12 @@ def _enable_queue_aware(monkeypatch) -> None:
     monkeypatch.setattr(InferenceRouter, "_ensure_queue_thread", classmethod(lambda cls: None))
 
 
+def test_default_model_matches_live_served_id(monkeypatch):
+    monkeypatch.delenv("VLLM_MODEL", raising=False)
+
+    assert InferenceRouter.model_name() == "aura-llm"
+
+
 def test_pick_node_random_tie_break_spreads_cold_start(monkeypatch):
     # Freeze random.choice to cycle through tied candidates so we can assert
     # the tie-break path is used (not always candidates[0]).


### PR DESCRIPTION
## Summary

- Align backend and deployment defaults with the live vLLM served model id ura-llm.
- Split the vLLM startup model path into VLLM_MODEL_PATH, keeping VLLM_MODEL as the OpenAI-compatible request model id.
- Add a regression test for the default model id.
- Add a redacted Markdown live chatbot smoke-test report for the Academics & Curriculum / Course Policies run.

## Root cause

The live vLLM nodes expose ura-llm from /v1/models, but multiple backend call sites and deployment defaults still requested Qwen/Qwen3-32B-AWQ as the model id. That is the HuggingFace weights path, not the served model name, so generation can fail and surface as the website's generic answer-generation error.

## Validation

- Live website guest smoke test: 10/10 requests returned HTTP 200 but all responses were generation-error fallbacks; full 110-question run is blocked by the anonymous 10/day quota.
- server/.venv/Scripts/python.exe -m pytest server/rag/pipeline/tests/test_inference_router.py -> 22 passed.
- server/.venv/Scripts/python.exe -B -m py_compile ... over edited backend Python files -> passed.
- server/.venv/Scripts/python.exe -m pytest server/rag/pipeline/tests could not collect locally because this venv is missing unrelated dependencies: jwt, astapi, psycopg2, ank_bm25, groq, s4, mcp, qdrant_client, langgraph, yaml.

## Notes

The included test report redacts raw internal deployment addresses while preserving the test outcomes and diagnosis.