### PR TITLE
fix(cd): enhance deployment logic to handle missing commit references

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -186,6 +186,15 @@ jobs:
               deploy_node2=true
               deploy_node3=true
               deploy_node4=true
+            elif ! git cat-file -e "${BEFORE}^{commit}" 2>/dev/null || ! git cat-file -e "${AFTER}^{commit}" 2>/dev/null; then
+              # Force-pushes can point github.event.before at a commit this
+              # long-lived runner clone does not have. Deploy everything safe
+              # instead of failing the deploy before planning.
+              echo "Diff endpoint unavailable: before=${BEFORE} after=${AFTER}; deploying all safe targets"
+              deploy_apps=true
+              deploy_node2=true
+              deploy_node3=true
+              deploy_node4=true
             else
               changed="$(git diff --name-only "${BEFORE}" "${AFTER}")"
               if printf '%s\n' "${changed}" | grep -E \


### PR DESCRIPTION
- Added a check for the existence of commit references before deployment to prevent failures during the deployment process.
- If the references are unavailable, the workflow will now deploy all safe targets instead of failing, ensuring a smoother deployment experience.