### PR TITLE
fix(auth): send relative redirect from guest route to avoid 0.0.0.0

### DIFF
--- a/aura/app/api/auth/guest/route.ts
+++ b/aura/app/api/auth/guest/route.ts
@@ -21,7 +21,7 @@ const SESSION_MAX_AGE = 8 * 60 * 60 // 8 h — matches authOptions
  *
  * Flow: /login → (click "Continue as Guest") → /api/auth/guest → /
  */
-export async function GET(request: Request) {
+export async function GET() {
   const cookieStore = await cookies()
   const guestCookies = readOrMintGuestCookies(cookieStore)
   const erpId = guestErpId(guestCookies)
@@ -46,7 +46,14 @@ export async function GET(request: Request) {
     ? "__Secure-next-auth.session-token"
     : "next-auth.session-token"
 
-  const response = NextResponse.redirect(new URL("/", request.url))
+  // Relative Location, not NextResponse.redirect(new URL("/", request.url)):
+  // in the standalone production server `request.url` is rebuilt from the
+  // container's bind address (HOSTNAME=0.0.0.0, PORT=3000), not the public
+  // host, so an absolute redirect sent the browser to https://0.0.0.0:3000/.
+  const response = new NextResponse(null, {
+    status: 307,
+    headers: { Location: "/" },
+  })
 
   // Set the guest identity cookies (used by /api/chat for quota keying).
   const guestOpts = guestCookieOptions()


### PR DESCRIPTION
## Summary

"Continue as Guest" was dead on the deployed app — the browser landed on `https://0.0.0.0:3000/` and failed with `ERR_CONNECTION_REFUSED`.

`/api/auth/guest` redirected with `NextResponse.redirect(new URL("/", request.url))`. In the standalone production server, Next rebuilds `request.url` from the container's **bind** address rather than the public host, and node1's frontend container runs with `HOSTNAME=0.0.0.0` / `PORT=3000`. So the route replied:

```
$ curl -skI https://10.100.97.71/api/auth/guest
HTTP/2 307
location: https://0.0.0.0:3000/
```

Google sign-in was unaffected because NextAuth uses `NEXTAUTH_URL` instead.

Fix: emit a relative `Location`, which the browser resolves against the origin it actually requested. Cookies (guest id/secret + NextAuth session) are unchanged.

Regression introduced in #375.

## Test plan

- [x] Reproduced on node1 — `location: https://0.0.0.0:3000/` before the fix
- [x] Fixed route returns `location: /` and still sets all three cookies (`aura-guest-id`, `aura-guest-secret`, `next-auth.session-token`)
- [x] Full guest flow with a cookie jar: `/api/auth/guest` → `/` returns 200; `/login` while holding the guest session redirects to `/`
- [x] `pnpm type-check` clean
- [x] `pnpm lint` clean on the changed file

## Notes

`proxy.ts` uses the same `new URL(…, req.url)` pattern but is **not** affected — Next normalizes middleware redirects to relative (verified on node1: `location: /login`), so it is left unchanged.

Needs a redeploy on node1 after merge (`git pull` + `docker compose build aura`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)