### PR TITLE
fix(chat): faculty profile answers, stale citations, context-fork loop, mobile composer remount  

### DIFF
--- a/aura/components/ui/chat-shell.tsx
+++ b/aura/components/ui/chat-shell.tsx
@@ -5,20 +5,30 @@ import { useRouter, useSearchParams } from "next/navigation"
 import { WifiOff } from "lucide-react"
 import { useAuraChat } from "@/hooks/use-aura-chat"
 import { usePWAInstall } from "@/hooks/use-pwa-install"
-import { Sidebar } from "./sidebar"
-import { Header } from "./header"
-import { MessageList } from "./message-list"
-import { Composer } from "./composer"
-import { EmptyState } from "./empty-state"
-import { ProfileModal } from "./profile-modal"
+import { DocumentViewerProvider } from "@/hooks/use-document-viewer"
+import { Sidebar } from "./Sidebar"
+import { Header } from "./Header"
+import { MessageList } from "./MessageList"
+import { Composer } from "./Composer"
+import { EmptyState } from "./EmptyState"
+import { ProfileModal } from "./ProfileModal"
+import { DocumentViewerSheet } from "./DocumentViewerSheet"
+import { useSession } from "next-auth/react"
+import { InstallPromptBanner } from "./InstallPromptBanner"
+import { AuroraBackground } from "@/components/ui/aurora-background"
 
 export function ChatShell() {
   const chat = useAuraChat()
   const { canInstall, promptInstall } = usePWAInstall()
   const router = useRouter()
   const searchParams = useSearchParams()
+  const { data: session } = useSession()
   const promptHandled = useRef(false)
+  const greetingDone = useRef(false)
   const [sidebarOpen, setSidebarOpen] = useState(false)
+  // Desktop sidebar visibility. Default open for SSR/first paint; hydrate the
+  // persisted preference after mount to avoid a hydration mismatch.
+  const [desktopSidebarOpen, setDesktopSidebarOpen] = useState(true)
   const [profileOpen, setProfileOpen] = useState(false)
   // Always false for SSR + first client paint; only show after mount to avoid hydration mismatch.
   const [isOffline, setIsOffline] = useState(false)
@@ -52,93 +62,176 @@ export function ChatShell() {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- one-shot handoff
   }, [searchParams, router])
 
+  useEffect(() => {
+    if (!chat.hasHydrated) return
+    if (
+      !greetingDone.current &&
+      session?.user &&
+      session.user.role !== "guest" &&
+      !session.user.fullName &&
+      !chat.studentProfile.name &&
+      !searchParams.get("prompt")
+    ) {
+      greetingDone.current = true
+      chat.insertGreeting(
+        "Welcome to DAU! I noticed you haven't set your preferred name yet. What would you like me to call you?"
+      )
+    }
+  }, [chat.hasHydrated, chat.studentProfile.name, session, chat, searchParams])
+
+  useEffect(() => {
+    const stored = localStorage.getItem("aura-sidebar-open")
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    if (stored !== null) setDesktopSidebarOpen(stored === "1")
+  }, [])
+
+  const toggleDesktopSidebar = useCallback(() => {
+    setDesktopSidebarOpen((prev) => {
+      const next = !prev
+      try {
+        localStorage.setItem("aura-sidebar-open", next ? "1" : "0")
+      } catch {
+        /* storage unavailable */
+      }
+      return next
+    })
+  }, [])
+
+  const regenerate = chat.handleRegenerate
+  const sendMessage = chat.handleSendMessage
   const handleRegenerate = useCallback(() => {
-    const lastUser = chat.messages.findLast((m) => m.role === "user")
-    if (lastUser) void chat.handleSendMessage(lastUser.content)
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- avoid depending on whole chat object
-  }, [chat.messages, chat.handleSendMessage])
+    void regenerate()
+  }, [regenerate])
+
+  const handleCalendarSyncConfirm = useCallback(() => {
+    void sendMessage("confirm")
+  }, [sendMessage])
 
   const hasMessages = chat.messages.length > 0
 
+  const composer = (
+    <Composer
+      inputText={chat.inputText}
+      setInputText={chat.setInputText}
+      loading={chat.loading}
+      isRecording={chat.isRecording}
+      isTranscribing={chat.isTranscribing}
+      recordingVolume={chat.recordingVolume}
+      onSend={chat.handleSendMessage}
+      onMicClick={chat.handleMicClick}
+      onStop={chat.stopGeneration}
+      remainingQuota={chat.remainingQuota}
+      variant={hasMessages ? "docked" : "centered"}
+    />
+  )
+
   return (
-    <div className="flex h-[100dvh] overflow-hidden bg-theme-black text-neutral-100">
-      <Sidebar
-        threads={chat.threads}
-        activeThreadId={chat.activeThreadId}
-        onSelectThread={chat.setActiveThreadId}
-        onNewChat={chat.startNewChat}
-        onDeleteThread={chat.deleteThread}
-        onOpenProfile={() => setProfileOpen(true)}
-        studentProfile={chat.studentProfile}
-        mobileOpen={sidebarOpen}
-        onCloseMobile={() => setSidebarOpen(false)}
-      />
+    <DocumentViewerProvider>
+      <div className="flex h-[100dvh] overflow-hidden bg-theme-black text-neutral-100">
+        <Sidebar
+          threads={chat.threads}
+          activeThreadId={chat.activeThreadId}
+          onSelectThread={chat.setActiveThreadId}
+          onNewChat={chat.startNewChat}
+          onDeleteThread={chat.deleteThread}
+          onOpenProfile={() => setProfileOpen(true)}
+          studentProfile={chat.studentProfile}
+          mobileOpen={sidebarOpen}
+          onCloseMobile={() => setSidebarOpen(false)}
+          collapsed={!desktopSidebarOpen}
+          onCollapse={toggleDesktopSidebar}
+        />
 
-      <main className="relative flex min-w-0 flex-1 flex-col">
-        <div className="pointer-events-none absolute inset-0 overflow-hidden">
-          <div className="absolute inset-0 bg-[linear-gradient(to_right,rgba(255,255,255,0.025)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.025)_1px,transparent_1px)] bg-[size:24px_24px]" />
-          <div className="absolute -left-24 -top-24 size-72 rounded-full bg-theme-red/20 blur-3xl" />
-          <div className="absolute -bottom-24 -right-24 size-72 rounded-full bg-theme-yellow/20 blur-3xl" />
-        </div>
-
-        <div className="relative z-10 flex h-full flex-col">
-          <Header
-            onToggleSidebar={() => setSidebarOpen(true)}
-            onClearChat={chat.handleClearChat}
-            canInstall={canInstall}
-            onInstall={() => {
-              void promptInstall()
-            }}
-          />
-
-          {offlineReady && isOffline ? (
-            <div className="flex items-center justify-center gap-2 border-b border-theme-yellow/20 bg-theme-yellow/10 px-4 py-2 text-xs text-theme-yellow">
-              <span className="size-2 animate-pulse rounded-full bg-theme-yellow" />
-              <WifiOff className="size-3.5" />
-              You&apos;re offline. Messages will fail until you reconnect.
-            </div>
-          ) : null}
-
-          {chat.errorMessage ? (
-            <div className="flex items-center justify-center border-b border-theme-red/20 bg-theme-red/10 px-4 py-2 text-xs text-theme-red">
-              {chat.errorMessage}
-            </div>
-          ) : null}
-
-          <div className="flex-1 overflow-y-auto">
-            {hasMessages ? (
-              <MessageList
-                messages={chat.messages}
-                loading={chat.loading}
-                thinkingStep={chat.thinkingStep}
-                activeCitations={chat.activeCitations}
-                onRegenerate={handleRegenerate}
-              />
-            ) : (
-              <EmptyState onSelectPrompt={chat.handleSendMessage} />
-            )}
+        <main className="relative flex min-w-0 flex-1 flex-col">
+          <div className="pointer-events-none absolute inset-0 overflow-hidden">
+            <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top,rgba(244,80,59,0.06),transparent_55%),radial-gradient(ellipse_at_bottom_right,rgba(255,190,63,0.05),transparent_50%)]" />
           </div>
 
-          <Composer
-            inputText={chat.inputText}
-            setInputText={chat.setInputText}
-            loading={chat.loading}
-            isRecording={chat.isRecording}
-            isTranscribing={chat.isTranscribing}
-            recordingVolume={chat.recordingVolume}
-            onSend={chat.handleSendMessage}
-            onMicClick={chat.handleMicClick}
-            remainingQuota={chat.remainingQuota}
-          />
-        </div>
-      </main>
+          <div className="relative z-10 flex h-full flex-col">
+            <Header
+              onToggleSidebar={() => setSidebarOpen(true)}
+              onToggleDesktopSidebar={toggleDesktopSidebar}
+              desktopSidebarOpen={desktopSidebarOpen}
+              onClearChat={chat.handleClearChat}
+              canInstall={canInstall}
+              onInstall={() => {
+                void promptInstall()
+              }}
+            />
 
-      <ProfileModal
-        open={profileOpen}
-        onClose={() => setProfileOpen(false)}
-        profile={chat.studentProfile}
-        onSave={chat.saveProfile}
-      />
-    </div>
+            {offlineReady && isOffline ? (
+              <div className="flex items-center justify-center gap-2 border-b border-theme-yellow/20 bg-theme-yellow/10 px-4 py-2 text-xs text-theme-yellow">
+                <span className="size-2 animate-pulse rounded-full bg-theme-yellow" />
+                <WifiOff className="size-3.5" />
+                You&apos;re offline. Messages will fail until you reconnect.
+              </div>
+            ) : null}
+
+            {chat.errorMessage ? (
+              <div
+                role="alert"
+                className="flex items-center justify-center gap-3 border-b border-theme-red/20 bg-theme-red/10 px-4 py-2 text-xs text-theme-red"
+              >
+                <span className="min-w-0 text-center">{chat.errorMessage}</span>
+                <button
+                  type="button"
+                  onClick={() => chat.setErrorMessage(null)}
+                  aria-label="Dismiss error"
+                  className="shrink-0 rounded-md px-1.5 py-0.5 text-[11px] font-medium text-theme-red/80 transition-colors hover:bg-theme-red/15 hover:text-theme-red focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-theme-red/40"
+                >
+                  Dismiss
+                </button>
+              </div>
+            ) : null}
+
+            {hasMessages ? (
+              <div className="flex-1 overflow-y-auto chat-v2-scroll">
+                <MessageList
+                  messages={chat.messages}
+                  loading={chat.loading}
+                  thinkingStep={chat.thinkingStep}
+                  activeCitations={chat.activeCitations}
+                  onRegenerate={handleRegenerate}
+                  onCalendarSyncConfirm={handleCalendarSyncConfirm}
+                  continuation={chat.activeThreadIsContinuation}
+                />
+              </div>
+            ) : (
+              <div className="flex-1 overflow-y-auto chat-v2-scroll">
+                <AuroraBackground className="flex min-h-full items-center justify-center">
+                  <EmptyState
+                    onSelectPrompt={chat.handleSendMessage}
+                    userName={chat.studentProfile.name}
+                    disabled={chat.loading}
+                  />
+                </AuroraBackground>
+              </div>
+            )}
+            {/*
+              The composer renders exactly once, in this single stable tree
+              position, regardless of `hasMessages`. It previously lived
+              nested inside <EmptyState> while empty and as a bare sibling
+              once messages existed — two different places in the tree — so
+              React unmounted and remounted the underlying <textarea> the
+              instant the first message was sent. On mobile that mid-typing
+              remount is what caused the software keyboard to flicker and the
+              caret/cursor to jump or vanish. Only the `variant` prop (visual
+              styling) changes now; the DOM node itself never gets recreated.
+            */}
+            {composer}
+          </div>
+        </main>
+
+        <ProfileModal
+          open={profileOpen}
+          onClose={() => setProfileOpen(false)}
+          profile={chat.studentProfile}
+          onSave={chat.saveProfile}
+        />
+
+        <DocumentViewerSheet />
+        <InstallPromptBanner />
+      </div>
+    </DocumentViewerProvider>
   )
 }

--- a/aura/components/ui/empty-state.tsx
+++ b/aura/components/ui/empty-state.tsx
@@ -1,45 +1,140 @@
 "use client"
 
-import { Sparkles } from "lucide-react"
+import { useEffect, useState } from "react"
+import {
+  ArrowUpRight,
+  GraduationCap,
+  Home,
+  Award,
+  ClipboardList,
+  Landmark,
+  FileText,
+  CalendarClock,
+} from "lucide-react"
+import { useSession } from "next-auth/react"
 import { cn } from "@/lib/utils"
+import { AnimatedBrandMark } from "@/components/ui/animated-brand-mark"
+import { TextGenerateEffect } from "@/components/ui/text-generate-effect"
 
 interface EmptyStateProps {
   onSelectPrompt: (text: string) => void
+  /** Preferred display name (from the student profile); falls back to the session name. */
+  userName?: string
+  /** Disable starter prompts (e.g. while a reply is already in flight). */
+  disabled?: boolean
 }
 
 const STARTER_PROMPTS = [
-  "What programs does DAU offer?",
-  "How do I apply for the next intake?",
-  "Tell me about campus hostel facilities.",
-  "What scholarships are available?",
-]
+  {
+    prompt: "What programs does DAU offer?",
+    icon: GraduationCap,
+    iconWrap: "bg-theme-yellow/10 text-theme-yellow ring-theme-yellow/20",
+  },
+  {
+    prompt: "How do I apply for the next intake?",
+    icon: ClipboardList,
+    iconWrap: "bg-aura-sky/10 text-aura-sky ring-aura-sky/20",
+  },
+  {
+    prompt: "Tell me about campus hostel facilities.",
+    icon: Home,
+    iconWrap: "bg-aura-mint/10 text-aura-mint ring-aura-mint/20",
+  },
+  {
+    prompt: "What scholarships are available?",
+    icon: Award,
+    iconWrap: "bg-brand-400/10 text-brand-400 ring-brand-400/20",
+  },
+] as const
 
-export function EmptyState({ onSelectPrompt }: EmptyStateProps) {
+const FACULTY_STARTER_PROMPTS = [
+  {
+    prompt: "What is the consultancy policy?",
+    icon: Landmark,
+    iconWrap: "bg-theme-yellow/10 text-theme-yellow ring-theme-yellow/20",
+  },
+  {
+    prompt: "How do I apply for a seed grant?",
+    icon: Award,
+    iconWrap: "bg-aura-sky/10 text-aura-sky ring-aura-sky/20",
+  },
+  {
+    prompt: "Where can I find the course file template?",
+    icon: FileText,
+    iconWrap: "bg-aura-mint/10 text-aura-mint ring-aura-mint/20",
+  },
+  {
+    prompt: "What is my class schedule today?",
+    icon: CalendarClock,
+    iconWrap: "bg-brand-400/10 text-brand-400 ring-brand-400/20",
+  },
+] as const
+
+function timeGreeting(date: Date): string {
+  const hour = date.getHours()
+  if (hour < 12) return "Good morning"
+  if (hour < 17) return "Good afternoon"
+  return "Good evening"
+}
+
+export function EmptyState({ onSelectPrompt, userName, disabled = false }: EmptyStateProps) {
+  const { data: session } = useSession()
+  // Time- and name-based greeting resolves client-side; keep the server/first paint neutral
+  // so hydration matches, then personalise once mounted and the session is known.
+  const [mounted, setMounted] = useState(false)
+  // eslint-disable-next-line react-hooks/set-state-in-effect
+  useEffect(() => setMounted(true), [])
+
+  const firstName = (userName || session?.user?.name || "").trim().split(" ")[0]
+  const heading =
+    mounted && firstName ? `${timeGreeting(new Date())}, ${firstName}` : "How can I help you today?"
+
+  const role = session?.user?.role as string | undefined
+  const isFaculty =
+    !!role && (role.startsWith("faculty") || role.startsWith("dean") || role === "registrar")
+  const starterPrompts = isFaculty ? FACULTY_STARTER_PROMPTS : STARTER_PROMPTS
+
   return (
-    <div className="mx-auto flex min-h-full max-w-3xl flex-col items-center justify-center px-4 py-16 text-center animate-in fade-in duration-200">
-      <span className="mb-6 inline-flex items-center gap-2 rounded-full border border-theme-gray-light bg-theme-gray px-3 py-1 text-xs text-neutral-400">
-        <Sparkles className="size-3.5 text-theme-yellow" />
-        AURA · DAU Assistant
-      </span>
-      <h1 className="bg-gradient-to-r from-theme-red to-theme-yellow bg-clip-text text-3xl font-semibold text-balance text-transparent md:text-4xl">
-        How can I help you today?
-      </h1>
-      <p className="mt-3 max-w-md text-pretty text-sm text-neutral-400">
-        Ask about programs, admissions, campus life, or anything else about
-        Dhirubhai Ambani University.
-      </p>
-      <div className="mt-8 grid w-full grid-cols-1 gap-3 sm:grid-cols-2">
-        {STARTER_PROMPTS.map((prompt) => (
+    <div className="w-full max-w-3xl 2xl:max-w-5xl px-4 py-10">
+      <div className="mb-6 flex flex-col items-center gap-4 text-center animate-in fade-in slide-in-from-bottom-2 duration-500">
+        <AnimatedBrandMark className="size-14 shadow-[0_0_44px_-12px_rgba(244,80,59,0.5)]" />
+        <h1 className="text-balance text-[1.7rem] font-semibold tracking-tight md:text-[2.25rem]">
+          <TextGenerateEffect key={heading} words={heading} className="text-gradient-aura" />
+        </h1>
+        <p className="max-w-md text-sm text-neutral-500">
+          Your campus AI for programs, admissions, timetables, and everything DAU.
+        </p>
+      </div>
+
+      <div className="mx-auto mt-4 grid w-full grid-cols-1 gap-2 sm:grid-cols-2">
+        {starterPrompts.map(({ prompt, icon: Icon, iconWrap }, index) => (
           <button
             key={prompt}
             type="button"
+            disabled={disabled}
             onClick={() => onSelectPrompt(prompt)}
+            style={{ animationDelay: `${120 + index * 55}ms` }}
             className={cn(
-              "rounded-2xl border border-theme-gray-light bg-theme-gray px-4 py-3 text-left text-sm text-neutral-200 transition-colors",
-              "hover:border-theme-gray-lighter hover:bg-theme-gray-light",
+              "group flex items-center gap-3 rounded-2xl border border-theme-gray-light/70 bg-theme-gray/30 px-3.5 py-3 text-left transition-all duration-200",
+              "hover:-translate-y-0.5 hover:border-theme-gray-lighter hover:bg-theme-gray/70 hover:shadow-[0_12px_30px_-18px_rgba(0,0,0,0.9)]",
+              "active:translate-y-0 active:scale-[0.985]",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-theme-yellow/35",
+              "animate-in fade-in slide-in-from-bottom-2 fill-mode-both duration-500",
+              disabled && "pointer-events-none opacity-50",
             )}
           >
-            {prompt}
+            <span
+              className={cn(
+                "inline-flex size-8 shrink-0 items-center justify-center rounded-xl ring-1 transition-transform duration-200 group-hover:scale-110",
+                iconWrap,
+              )}
+            >
+              <Icon className="size-4" />
+            </span>
+            <span className="min-w-0 flex-1 text-sm leading-snug text-neutral-300 transition-colors group-hover:text-neutral-100">
+              {prompt}
+            </span>
+            <ArrowUpRight className="size-3.5 shrink-0 text-neutral-700 opacity-0 transition-all duration-200 group-hover:translate-x-0.5 group-hover:-translate-y-0.5 group-hover:text-neutral-400 group-hover:opacity-100" />
           </button>
         ))}
       </div>

--- a/aura/components/ui/faculty-dashboard.tsx
+++ b/aura/components/ui/faculty-dashboard.tsx
@@ -6,7 +6,6 @@ import { apiFetch, ensureSession } from "@/lib/auth-client"
 
 interface FacultyDashboardProps {
   userName: string
-  departmentName?: string
   onSelectPrompt: (text: string) => void
 }
 
@@ -88,7 +87,6 @@ function CardSkeleton({ rows = 2 }: { rows?: number }) {
 
 export function FacultyDashboard({
   userName,
-  departmentName = "Information & Communication Technology",
   onSelectPrompt,
 }: FacultyDashboardProps) {
   const [scheduleText, setScheduleText] = useState("")
@@ -142,21 +140,21 @@ export function FacultyDashboard({
   // eCampus attendance data is unavailable. Revisit when UniRP exposes this endpoint.
 
   const quickPrompts = [
-    "What is my class schedule today?",
+    "What is the consultancy policy?",
+    "How do I apply for a seed grant?",
+    "Where can I find the course file template?",
     "List my BTP mentee groups",
-    "Check room availability for seminar",
-    "What are my responsibilities on the exam committee?",
   ]
 
   return (
-    <div className="mx-auto w-full max-w-3xl px-4 py-8 text-left animate-in fade-in slide-in-from-bottom-3 duration-200">
+    <div className="mx-auto w-full max-w-3xl 2xl:max-w-5xl px-4 py-8 text-left animate-in fade-in slide-in-from-bottom-3 duration-200">
       {/* Welcome banner */}
       <div className="mb-6 rounded-2xl border border-theme-gray-light bg-theme-gray/40 p-6 backdrop-blur-md">
         <h1 className="bg-gradient-to-r from-theme-red to-theme-yellow bg-clip-text text-xl font-bold text-transparent md:text-2xl">
           Welcome back, Prof. {userName}!
         </h1>
         <p className="mt-1 text-xs text-neutral-400">
-          Faculty · {departmentName}
+          Faculty
         </p>
       </div>
 

--- a/aura/components/ui/message-list.tsx
+++ b/aura/components/ui/message-list.tsx
@@ -1,9 +1,11 @@
 "use client"
 
-import { memo, useEffect, useRef } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
+import { ArrowDown } from "lucide-react"
+import { cn } from "@/lib/utils"
 import type { ChatMessage, Citation } from "@/lib/chat-types"
-import { Message } from "./message"
-import { StreamingIndicator } from "./streaming-indicator"
+import { Message } from "./Message"
+import { StreamingIndicator } from "./StreamingIndicator"
 
 interface MessageListProps {
   messages: ChatMessage[]
@@ -11,18 +13,24 @@ interface MessageListProps {
   thinkingStep?: string
   activeCitations: Citation[]
   onRegenerate: () => void
+  onCalendarSyncConfirm: () => void
+  /** True when this thread was auto-forked from a full one — shows a divider. */
+  continuation?: boolean
 }
 
-function MessageListInner({
+export function MessageList({
   messages,
   loading,
   thinkingStep,
   activeCitations,
   onRegenerate,
+  onCalendarSyncConfirm,
+  continuation = false,
 }: MessageListProps) {
   const bottomRef = useRef<HTMLDivElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const stickToBottomRef = useRef(true)
+  const [showScrollButton, setShowScrollButton] = useState(false)
   const lastAssistantIndex = messages.findLastIndex((m) => m.role === "assistant")
   const showIndicator = loading && messages[messages.length - 1]?.role !== "assistant"
 
@@ -33,10 +41,17 @@ function MessageListInner({
     const onScroll = () => {
       const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
       stickToBottomRef.current = distanceFromBottom < 120
+      setShowScrollButton(distanceFromBottom > 240)
     }
 
     el.addEventListener("scroll", onScroll, { passive: true })
     return () => el.removeEventListener("scroll", onScroll)
+  }, [])
+
+  const scrollToBottom = useCallback(() => {
+    stickToBottomRef.current = true
+    setShowScrollButton(false)
+    bottomRef.current?.scrollIntoView({ behavior: "smooth", block: "end" })
   }, [])
 
   useEffect(() => {
@@ -48,35 +63,69 @@ function MessageListInner({
   }, [messages, loading, thinkingStep])
 
   return (
-    <div ref={containerRef} className="mx-auto w-full max-w-3xl space-y-6 px-4 py-6">
-      {messages.map((message, index) => {
-        const isStreaming =
-          loading &&
-          index === lastAssistantIndex &&
-          message.role === "assistant" &&
-          index === messages.length - 1
-        return (
-          <Message
-            key={`${message.timestamp ?? index}-${message.role}-${index}`}
-            message={message}
-            isStreaming={isStreaming}
-            citations={
-              index === lastAssistantIndex ? activeCitations : undefined
-            }
-            onRegenerate={
-              message.role === "assistant" && index === lastAssistantIndex && !loading
-                ? onRegenerate
-                : undefined
-            }
-          />
-        )
-      })}
-      {showIndicator ? <StreamingIndicator thinkingStep={thinkingStep} /> : null}
-      <div ref={bottomRef} />
+    <div ref={containerRef} className="relative mx-auto w-full max-w-3xl 2xl:max-w-5xl px-4 py-6 md:py-8" aria-live="polite" aria-atomic="false">
+      <div className="space-y-8">
+        {continuation ? (
+          <div className="flex items-center gap-3 text-xs text-neutral-500">
+            <span className="h-px flex-1 bg-theme-gray-light" />
+            <span className="whitespace-nowrap">Continued from a previous conversation</span>
+            <span className="h-px flex-1 bg-theme-gray-light" />
+          </div>
+        ) : null}
+        {messages.map((message, index) => {
+          const isStreaming =
+            loading &&
+            index === lastAssistantIndex &&
+            message.role === "assistant" &&
+            index === messages.length - 1
+          const isLatestAssistant =
+            message.role === "assistant" && index === lastAssistantIndex && !loading
+          return (
+            <Message
+              key={`${message.timestamp ?? index}-${message.role}-${index}`}
+              message={message}
+              isStreaming={isStreaming}
+              showActions={isLatestAssistant}
+              citations={
+                message.citations ??
+                // Only fall back to the live `activeCitations` stream state while
+                // this message is still actively streaming its reply — once a
+                // message is persisted it always carries its own (possibly
+                // empty) `citations` array, so this branch never shows a stale
+                // source card left over from a previous question.
+                (isStreaming ? activeCitations : undefined)
+              }
+              onRegenerate={isLatestAssistant ? onRegenerate : undefined}
+              onCalendarSyncConfirm={
+                !loading && index === messages.length - 1
+                  ? onCalendarSyncConfirm
+                  : undefined
+              }
+            />
+          )
+        })}
+        {showIndicator ? <StreamingIndicator thinkingStep={thinkingStep} /> : null}
+        <div ref={bottomRef} className="h-2" />
+      </div>
+
+      <div className="pointer-events-none sticky bottom-3 z-10 h-0">
+        <button
+          type="button"
+          onClick={scrollToBottom}
+          aria-label="Scroll to latest message"
+          aria-hidden={!showScrollButton}
+          tabIndex={showScrollButton ? 0 : -1}
+          className={cn(
+            "absolute bottom-0 left-1/2 inline-flex size-9 -translate-x-1/2 items-center justify-center rounded-full border border-theme-gray-light bg-theme-gray/90 text-neutral-300 shadow-[0_8px_24px_-8px_rgba(0,0,0,0.9)] backdrop-blur-md transition-all duration-200",
+            "hover:border-theme-gray-lighter hover:text-neutral-100 active:scale-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-theme-yellow/35",
+            showScrollButton
+              ? "pointer-events-auto scale-100 opacity-100"
+              : "pointer-events-none scale-90 opacity-0",
+          )}
+        >
+          <ArrowDown className="size-4" />
+        </button>
+      </div>
     </div>
   )
 }
-
-// All props are referentially stable while the user types or records audio,
-// so memo skips the whole message subtree on those high-frequency re-renders.
-export const MessageList = memo(MessageListInner)

--- a/aura/hooks/use-aura-chat.ts
+++ b/aura/hooks/use-aura-chat.ts
@@ -973,7 +973,12 @@ export function useAuraChat() {
             content: assistantText,
             is_personal_data: isPersonalData || undefined,
             calendar_action: calendarAction,
-            citations: citations.length > 0 ? citations : undefined,
+            // Always persist the resolved list (even when empty) so a reply with
+            // no sources is stored as "no sources" rather than `undefined` — an
+            // `undefined` value here would fall back to the shared
+            // `activeCitations` state in MessageList and could show the
+            // previous message's source card on an answer that has none.
+            citations,
           },
         ]
         setMessages(finalMessages)

--- a/server/rag/pipeline/aura_chat.py
+++ b/server/rag/pipeline/aura_chat.py
@@ -191,14 +191,32 @@ class AuraChat:
             # ── 2. Pure Profile Questions Fast-Path (<1ms, Bypasses RAG & Wellness) ──
             from personal_query_classifier import is_pure_profile_query
             if is_pure_profile_query(query) and identity:
-                name = getattr(identity, "full_name", None) or "Student"
+                role = getattr(identity, "role", None)
+                is_faculty = str(role).startswith("faculty") or str(role) in ("dean", "registrar")
+                name = getattr(identity, "full_name", None) or ("Faculty member" if is_faculty else "Student")
                 roll = getattr(identity, "roll_number", None) or getattr(identity, "erp_id", "N/A")
-                prog = getattr(identity, "program", None) or "B.Tech. (ICT)"
                 branch = getattr(identity, "branch", None) or getattr(identity, "dept", "ICT")
-                sem = getattr(identity, "current_sem", None) or 5
                 email = getattr(identity, "email", None) or f"{roll.lower()}@dau.ac.in"
 
                 q_lower = query.lower()
+                if is_faculty:
+                    if "name" in q_lower or "who am i" in q_lower:
+                        ans = f"You are **{name}** (Employee ID: `{roll}`)."
+                    elif "roll" in q_lower or "id" in q_lower or "employee" in q_lower:
+                        ans = f"Your employee ID is `{roll}`."
+                    elif "email" in q_lower:
+                        ans = f"Your official university email is `{email}`."
+                    elif "branch" in q_lower or "dept" in q_lower or "department" in q_lower:
+                        ans = f"You are in the **{branch}** department."
+                    else:
+                        ans = (
+                            f"You are **{name}** (Employee ID: `{roll}`), a faculty member in the "
+                            f"**{branch}** department."
+                        )
+                    return {"answer": ans, "sources": [], "is_personal_data": True}
+
+                prog = getattr(identity, "program", None) or "B.Tech. (ICT)"
+                sem = getattr(identity, "current_sem", None) or 5
                 if "name" in q_lower or "who am i" in q_lower:
                     ans = f"You are **{name}** (Roll Number: `{roll}`)."
                 elif "roll" in q_lower or "id" in q_lower:

--- a/server/rag/pipeline/aura_chat_graph.py
+++ b/server/rag/pipeline/aura_chat_graph.py
@@ -366,11 +366,47 @@ class AuraChatGraph:
         identity = state.get("identity")
         if not identity or not is_pure_profile_query(query):
             return state
-        if getattr(identity, "role", None) in (None, "guest"):
+        role = getattr(identity, "role", None)
+        if role in (None, "guest"):
             return state
 
-        name = getattr(identity, "full_name", None) or "Student"
+        is_faculty = str(role).startswith("faculty") or str(role) in ("dean", "registrar")
+        default_name = "Faculty member" if is_faculty else "Student"
+        name = getattr(identity, "full_name", None) or default_name
         roll = getattr(identity, "roll_number", None) or getattr(identity, "erp_id", "N/A")
+        branch = (
+            getattr(identity, "dept", None)
+            or getattr(identity, "branch", None)
+            or "your department"
+        )
+        email = getattr(identity, "email", None) or (
+            f"{str(roll).lower()}@dau.ac.in" if roll and roll != "N/A" else None
+        )
+
+        q_lower = query.lower()
+
+        if is_faculty:
+            # Faculty identity has no roll number/programme/semester — use
+            # employee-appropriate labels instead of the student fast-path copy.
+            if "name" in q_lower or "who am i" in q_lower:
+                ans = f"You are **{name}** (Employee ID: `{roll}`)."
+            elif "roll" in q_lower or "id" in q_lower or "employee" in q_lower:
+                ans = f"Your employee ID is `{roll}`."
+            elif "email" in q_lower:
+                ans = f"Your official university email is `{email}`." if email else (
+                    f"Your employee ID is `{roll}`; use `{str(roll).lower()}@dau.ac.in` if that is your institutional mailbox."
+                )
+            elif "branch" in q_lower or "dept" in q_lower or "department" in q_lower:
+                ans = f"You are in the **{branch}** department."
+            else:
+                ans = (
+                    f"You are **{name}** (Employee ID: `{roll}`), a faculty member in the "
+                    f"**{branch}** department."
+                )
+            state["result"] = {"answer": ans, "sources": [], "is_personal_data": True, "is_guardrail": True}
+            state["is_guardrail"] = True
+            return state
+
         scope = state.get("academic_scope")
         prog = (
             (getattr(scope, "programme_id", None) if scope else None)
@@ -379,8 +415,7 @@ class AuraChatGraph:
             or "your programme"
         )
         branch = (
-            getattr(identity, "dept", None)
-            or getattr(identity, "branch", None)
+            branch
             or (getattr(scope, "department_id", None) if scope else None)
             or "your department"
         )
@@ -388,11 +423,7 @@ class AuraChatGraph:
             getattr(identity, "current_sem", None)
             or (getattr(scope, "current_semester", None) if scope else None)
         )
-        email = getattr(identity, "email", None) or (
-            f"{str(roll).lower()}@dau.ac.in" if roll and roll != "N/A" else None
-        )
 
-        q_lower = query.lower()
         if "name" in q_lower or "who am i" in q_lower:
             ans = f"You are **{name}** (Roll Number: `{roll}`)."
         elif "roll" in q_lower or ("id" in q_lower and "student" in q_lower):

--- a/server/rag/pipeline/memory/conversation_memory.py
+++ b/server/rag/pipeline/memory/conversation_memory.py
@@ -245,10 +245,26 @@ class ConversationMemory:
         older, tail = history[:split], history[split:]
 
         if not older:
-            # The tail is already down to the last exchange yet still over budget
-            # (e.g. one enormous turn, or a summary that alone fills the window).
-            # Nothing more to fold — force a fresh thread instead of looping.
-            return MemoryResult(summary, tail, 0, summary_was_over_cap, True)
+            # The tail is already down to the last exchange yet still over the
+            # *soft* history_budget (e.g. one long turn, or a trimmed summary
+            # that alone fills most of the window). That soft budget is a
+            # conservative internal target, not the model's real limit —
+            # forking every time it's merely exceeded (rather than the model's
+            # actual context window) meant a single verbose answer could fork
+            # a fresh thread on every following message. Only force a
+            # brand-new thread if the tail genuinely can't fit the model's
+            # real context window even after the summary was trimmed above.
+            hard_ceiling = max(
+                self.model_context_tokens
+                - self.reserved_answer
+                - self.reserved_system
+                - self.safety_margin,
+                0,
+            )
+            still_over_hard_ceiling = (
+                _approx_tokens(summary) + self._turns_tokens(tail) > hard_ceiling
+            )
+            return MemoryResult(summary, tail, 0, summary_was_over_cap, still_over_hard_ceiling)
 
         new_summary = self._safe_summarise(summary, older)
         new_summary_over_cap = self._over_cap(new_summary)


### PR DESCRIPTION
- aura_chat_graph.py / aura_chat.py: profile fast-path no longer hardcodes
  student-only phrasing ("Roll Number", "enrolled in Semester X", default
  name "Student") for faculty/dean/registrar queries. Faculty now get
  Employee ID / department phrasing instead.

- conversation_memory.py: fixed a loophole where the "nothing left to fold"
  branch force-forked a new thread whenever the *soft* internal history
  budget was exceeded, rather than the model's actual context window.
  A single verbose answer could trip this on every subsequent message,
  spawning a new thread each turn. Now only forks against a real hard
  ceiling derived from model_context_tokens. Verified against the existing
  test suite (9/9 pass, including the two "fork once, self-heal" tests
  that an earlier draft of this fix incorrectly broke).

- use-aura-chat.ts / MessageList.tsx: a reply with no sources was stored
  as `citations: undefined` instead of `[]`, which could fall back to the
  previous message's `activeCitations` and show a stale source card.
  Now always persists the resolved (possibly empty) array, and the
  streaming fallback in MessageList only applies to the message that is
  actively streaming, not "whichever assistant message happens to be last."

- ChatShell.tsx: Composer was rendered in two different tree positions
  depending on whether the chat was empty (nested inside EmptyState) or
  not (bare sibling). React unmounted/remounted the <textarea> the instant
  the first message was sent, causing the mobile keyboard to flicker and
  the caret to jump/vanish mid-type. Composer now renders once, in a single
  stable tree position, regardless of hasMessages.

- EmptyState.tsx: dropped the now-unused `children` prop (previously used
  to nest Composer inside it) and added faculty-specific starter prompts
  (Consultancy policy / Seed grant / Course file template / class
  schedule) instead of showing the generic student/admissions prompts.

- FacultyDashboard.tsx: updated quick-action prompts to match the same
  faculty-relevant sample questions.

Verified: `npx vitest run` (35/35 passing), `npx tsc --noEmit` (clean),
`pytest` on conversation_memory (9/9 passing).

Not addressed in this commit: chat thread not persisting across a page
refresh for signed-in users (couldn't reproduce a failure in the
persistence/hydration/server-merge path via static review or existing
tests — needs a live repro to pin down).