### PR TITLE
fix(chat): faculty profile answers, stale citations, context-fork loop, mobile composer remount

### DIFF
--- a/aura/components/features/chat-ui/ChatShell.tsx
+++ b/aura/components/features/chat-ui/ChatShell.tsx
@@ -185,20 +185,17 @@ export function ChatShell() {
             ) : null}
 
             {hasMessages ? (
-              <>
-                <div className="flex-1 overflow-y-auto chat-v2-scroll">
-                  <MessageList
-                    messages={chat.messages}
-                    loading={chat.loading}
-                    thinkingStep={chat.thinkingStep}
-                    activeCitations={chat.activeCitations}
-                    onRegenerate={handleRegenerate}
-                    onCalendarSyncConfirm={handleCalendarSyncConfirm}
-                    continuation={chat.activeThreadIsContinuation}
-                  />
-                </div>
-                {composer}
-              </>
+              <div className="flex-1 overflow-y-auto chat-v2-scroll">
+                <MessageList
+                  messages={chat.messages}
+                  loading={chat.loading}
+                  thinkingStep={chat.thinkingStep}
+                  activeCitations={chat.activeCitations}
+                  onRegenerate={handleRegenerate}
+                  onCalendarSyncConfirm={handleCalendarSyncConfirm}
+                  continuation={chat.activeThreadIsContinuation}
+                />
+              </div>
             ) : (
               <div className="flex-1 overflow-y-auto chat-v2-scroll">
                 <AuroraBackground className="flex min-h-full items-center justify-center">
@@ -206,12 +203,22 @@ export function ChatShell() {
                     onSelectPrompt={chat.handleSendMessage}
                     userName={chat.studentProfile.name}
                     disabled={chat.loading}
-                  >
-                    {composer}
-                  </EmptyState>
+                  />
                 </AuroraBackground>
               </div>
             )}
+            {/*
+              The composer renders exactly once, in this single stable tree
+              position, regardless of `hasMessages`. It previously lived
+              nested inside <EmptyState> while empty and as a bare sibling
+              once messages existed — two different places in the tree — so
+              React unmounted and remounted the underlying <textarea> the
+              instant the first message was sent. On mobile that mid-typing
+              remount is what caused the software keyboard to flicker and the
+              caret/cursor to jump or vanish. Only the `variant` prop (visual
+              styling) changes now; the DOM node itself never gets recreated.
+            */}
+            {composer}
           </div>
         </main>
 

--- a/aura/components/features/chat-ui/EmptyState.tsx
+++ b/aura/components/features/chat-ui/EmptyState.tsx
@@ -1,12 +1,15 @@
 "use client"
 
-import { type ReactNode, useEffect, useState } from "react"
+import { useEffect, useState } from "react"
 import {
   ArrowUpRight,
   GraduationCap,
   Home,
   Award,
   ClipboardList,
+  Landmark,
+  FileText,
+  CalendarClock,
 } from "lucide-react"
 import { useSession } from "next-auth/react"
 import { cn } from "@/lib/utils"
@@ -19,8 +22,6 @@ interface EmptyStateProps {
   userName?: string
   /** Disable starter prompts (e.g. while a reply is already in flight). */
   disabled?: boolean
-  /** The composer, rendered between the greeting and the starter prompts. */
-  children?: ReactNode
 }
 
 const STARTER_PROMPTS = [
@@ -46,6 +47,29 @@ const STARTER_PROMPTS = [
   },
 ] as const
 
+const FACULTY_STARTER_PROMPTS = [
+  {
+    prompt: "What is the consultancy policy?",
+    icon: Landmark,
+    iconWrap: "bg-theme-yellow/10 text-theme-yellow ring-theme-yellow/20",
+  },
+  {
+    prompt: "How do I apply for a seed grant?",
+    icon: Award,
+    iconWrap: "bg-aura-sky/10 text-aura-sky ring-aura-sky/20",
+  },
+  {
+    prompt: "Where can I find the course file template?",
+    icon: FileText,
+    iconWrap: "bg-aura-mint/10 text-aura-mint ring-aura-mint/20",
+  },
+  {
+    prompt: "What is my class schedule today?",
+    icon: CalendarClock,
+    iconWrap: "bg-brand-400/10 text-brand-400 ring-brand-400/20",
+  },
+] as const
+
 function timeGreeting(date: Date): string {
   const hour = date.getHours()
   if (hour < 12) return "Good morning"
@@ -53,7 +77,7 @@ function timeGreeting(date: Date): string {
   return "Good evening"
 }
 
-export function EmptyState({ onSelectPrompt, userName, disabled = false, children }: EmptyStateProps) {
+export function EmptyState({ onSelectPrompt, userName, disabled = false }: EmptyStateProps) {
   const { data: session } = useSession()
   // Time- and name-based greeting resolves client-side; keep the server/first paint neutral
   // so hydration matches, then personalise once mounted and the session is known.
@@ -64,6 +88,11 @@ export function EmptyState({ onSelectPrompt, userName, disabled = false, childre
   const firstName = (userName || session?.user?.name || "").trim().split(" ")[0]
   const heading =
     mounted && firstName ? `${timeGreeting(new Date())}, ${firstName}` : "How can I help you today?"
+
+  const role = session?.user?.role as string | undefined
+  const isFaculty =
+    !!role && (role.startsWith("faculty") || role.startsWith("dean") || role === "registrar")
+  const starterPrompts = isFaculty ? FACULTY_STARTER_PROMPTS : STARTER_PROMPTS
 
   return (
     <div className="w-full max-w-3xl 2xl:max-w-5xl px-4 py-10">
@@ -77,10 +106,8 @@ export function EmptyState({ onSelectPrompt, userName, disabled = false, childre
         </p>
       </div>
 
-      {children ? <div className="w-full">{children}</div> : null}
-
       <div className="mx-auto mt-4 grid w-full grid-cols-1 gap-2 sm:grid-cols-2">
-        {STARTER_PROMPTS.map(({ prompt, icon: Icon, iconWrap }, index) => (
+        {starterPrompts.map(({ prompt, icon: Icon, iconWrap }, index) => (
           <button
             key={prompt}
             type="button"

--- a/aura/components/features/chat-ui/EmptyState.tsx
+++ b/aura/components/features/chat-ui/EmptyState.tsx
@@ -63,11 +63,6 @@ const FACULTY_STARTER_PROMPTS = [
     icon: FileText,
     iconWrap: "bg-aura-mint/10 text-aura-mint ring-aura-mint/20",
   },
-  {
-    prompt: "What is my class schedule today?",
-    icon: CalendarClock,
-    iconWrap: "bg-brand-400/10 text-brand-400 ring-brand-400/20",
-  },
 ] as const
 
 function timeGreeting(date: Date): string {

--- a/aura/components/features/chat-ui/FacultyDashboard.tsx
+++ b/aura/components/features/chat-ui/FacultyDashboard.tsx
@@ -143,7 +143,6 @@ export function FacultyDashboard({
     "What is the consultancy policy?",
     "How do I apply for a seed grant?",
     "Where can I find the course file template?",
-    "List my BTP mentee groups",
   ]
 
   return (

--- a/aura/components/features/chat-ui/FacultyDashboard.tsx
+++ b/aura/components/features/chat-ui/FacultyDashboard.tsx
@@ -140,10 +140,10 @@ export function FacultyDashboard({
   // eCampus attendance data is unavailable. Revisit when UniRP exposes this endpoint.
 
   const quickPrompts = [
-    "What is my class schedule today?",
+    "What is the consultancy policy?",
+    "How do I apply for a seed grant?",
+    "Where can I find the course file template?",
     "List my BTP mentee groups",
-    "Check room availability for seminar",
-    "What are my responsibilities on the exam committee?",
   ]
 
   return (

--- a/aura/components/features/chat-ui/MessageList.tsx
+++ b/aura/components/features/chat-ui/MessageList.tsx
@@ -88,7 +88,12 @@ export function MessageList({
               showActions={isLatestAssistant}
               citations={
                 message.citations ??
-                (index === lastAssistantIndex ? activeCitations : undefined)
+                // Only fall back to the live `activeCitations` stream state while
+                // this message is still actively streaming its reply — once a
+                // message is persisted it always carries its own (possibly
+                // empty) `citations` array, so this branch never shows a stale
+                // source card left over from a previous question.
+                (isStreaming ? activeCitations : undefined)
               }
               onRegenerate={isLatestAssistant ? onRegenerate : undefined}
               onCalendarSyncConfirm={

--- a/aura/hooks/use-aura-chat.ts
+++ b/aura/hooks/use-aura-chat.ts
@@ -973,7 +973,12 @@ export function useAuraChat() {
             content: assistantText,
             is_personal_data: isPersonalData || undefined,
             calendar_action: calendarAction,
-            citations: citations.length > 0 ? citations : undefined,
+            // Always persist the resolved list (even when empty) so a reply with
+            // no sources is stored as "no sources" rather than `undefined` — an
+            // `undefined` value here would fall back to the shared
+            // `activeCitations` state in MessageList and could show the
+            // previous message's source card on an answer that has none.
+            citations,
           },
         ]
         setMessages(finalMessages)

--- a/server/rag/pipeline/aura_chat.py
+++ b/server/rag/pipeline/aura_chat.py
@@ -191,14 +191,32 @@ class AuraChat:
             # ── 2. Pure Profile Questions Fast-Path (<1ms, Bypasses RAG & Wellness) ──
             from personal_query_classifier import is_pure_profile_query
             if is_pure_profile_query(query) and identity:
-                name = getattr(identity, "full_name", None) or "Student"
+                role = getattr(identity, "role", None)
+                is_faculty = str(role).startswith("faculty") or str(role) in ("dean", "registrar")
+                name = getattr(identity, "full_name", None) or ("Faculty member" if is_faculty else "Student")
                 roll = getattr(identity, "roll_number", None) or getattr(identity, "erp_id", "N/A")
-                prog = getattr(identity, "program", None) or "B.Tech. (ICT)"
                 branch = getattr(identity, "branch", None) or getattr(identity, "dept", "ICT")
-                sem = getattr(identity, "current_sem", None) or 5
                 email = getattr(identity, "email", None) or f"{roll.lower()}@dau.ac.in"
 
                 q_lower = query.lower()
+                if is_faculty:
+                    if "name" in q_lower or "who am i" in q_lower:
+                        ans = f"You are **{name}** (Employee ID: `{roll}`)."
+                    elif "roll" in q_lower or "id" in q_lower or "employee" in q_lower:
+                        ans = f"Your employee ID is `{roll}`."
+                    elif "email" in q_lower:
+                        ans = f"Your official university email is `{email}`."
+                    elif "branch" in q_lower or "dept" in q_lower or "department" in q_lower:
+                        ans = f"You are in the **{branch}** department."
+                    else:
+                        ans = (
+                            f"You are **{name}** (Employee ID: `{roll}`), a faculty member in the "
+                            f"**{branch}** department."
+                        )
+                    return {"answer": ans, "sources": [], "is_personal_data": True}
+
+                prog = getattr(identity, "program", None) or "B.Tech. (ICT)"
+                sem = getattr(identity, "current_sem", None) or 5
                 if "name" in q_lower or "who am i" in q_lower:
                     ans = f"You are **{name}** (Roll Number: `{roll}`)."
                 elif "roll" in q_lower or "id" in q_lower:

--- a/server/rag/pipeline/aura_chat_graph.py
+++ b/server/rag/pipeline/aura_chat_graph.py
@@ -366,11 +366,47 @@ class AuraChatGraph:
         identity = state.get("identity")
         if not identity or not is_pure_profile_query(query):
             return state
-        if getattr(identity, "role", None) in (None, "guest"):
+        role = getattr(identity, "role", None)
+        if role in (None, "guest"):
             return state
 
-        name = getattr(identity, "full_name", None) or "Student"
+        is_faculty = str(role).startswith("faculty") or str(role) in ("dean", "registrar")
+        default_name = "Faculty member" if is_faculty else "Student"
+        name = getattr(identity, "full_name", None) or default_name
         roll = getattr(identity, "roll_number", None) or getattr(identity, "erp_id", "N/A")
+        branch = (
+            getattr(identity, "dept", None)
+            or getattr(identity, "branch", None)
+            or "your department"
+        )
+        email = getattr(identity, "email", None) or (
+            f"{str(roll).lower()}@dau.ac.in" if roll and roll != "N/A" else None
+        )
+
+        q_lower = query.lower()
+
+        if is_faculty:
+            # Faculty identity has no roll number/programme/semester — use
+            # employee-appropriate labels instead of the student fast-path copy.
+            if "name" in q_lower or "who am i" in q_lower:
+                ans = f"You are **{name}** (Employee ID: `{roll}`)."
+            elif "roll" in q_lower or "id" in q_lower or "employee" in q_lower:
+                ans = f"Your employee ID is `{roll}`."
+            elif "email" in q_lower:
+                ans = f"Your official university email is `{email}`." if email else (
+                    f"Your employee ID is `{roll}`; use `{str(roll).lower()}@dau.ac.in` if that is your institutional mailbox."
+                )
+            elif "branch" in q_lower or "dept" in q_lower or "department" in q_lower:
+                ans = f"You are in the **{branch}** department."
+            else:
+                ans = (
+                    f"You are **{name}** (Employee ID: `{roll}`), a faculty member in the "
+                    f"**{branch}** department."
+                )
+            state["result"] = {"answer": ans, "sources": [], "is_personal_data": True, "is_guardrail": True}
+            state["is_guardrail"] = True
+            return state
+
         scope = state.get("academic_scope")
         prog = (
             (getattr(scope, "programme_id", None) if scope else None)
@@ -379,8 +415,7 @@ class AuraChatGraph:
             or "your programme"
         )
         branch = (
-            getattr(identity, "dept", None)
-            or getattr(identity, "branch", None)
+            branch
             or (getattr(scope, "department_id", None) if scope else None)
             or "your department"
         )
@@ -388,11 +423,7 @@ class AuraChatGraph:
             getattr(identity, "current_sem", None)
             or (getattr(scope, "current_semester", None) if scope else None)
         )
-        email = getattr(identity, "email", None) or (
-            f"{str(roll).lower()}@dau.ac.in" if roll and roll != "N/A" else None
-        )
 
-        q_lower = query.lower()
         if "name" in q_lower or "who am i" in q_lower:
             ans = f"You are **{name}** (Roll Number: `{roll}`)."
         elif "roll" in q_lower or ("id" in q_lower and "student" in q_lower):

--- a/server/rag/pipeline/memory/conversation_memory.py
+++ b/server/rag/pipeline/memory/conversation_memory.py
@@ -245,10 +245,26 @@ class ConversationMemory:
         older, tail = history[:split], history[split:]
 
         if not older:
-            # The tail is already down to the last exchange yet still over budget
-            # (e.g. one enormous turn, or a summary that alone fills the window).
-            # Nothing more to fold — force a fresh thread instead of looping.
-            return MemoryResult(summary, tail, 0, summary_was_over_cap, True)
+            # The tail is already down to the last exchange yet still over the
+            # *soft* history_budget (e.g. one long turn, or a trimmed summary
+            # that alone fills most of the window). That soft budget is a
+            # conservative internal target, not the model's real limit —
+            # forking every time it's merely exceeded (rather than the model's
+            # actual context window) meant a single verbose answer could fork
+            # a fresh thread on every following message. Only force a
+            # brand-new thread if the tail genuinely can't fit the model's
+            # real context window even after the summary was trimmed above.
+            hard_ceiling = max(
+                self.model_context_tokens
+                - self.reserved_answer
+                - self.reserved_system
+                - self.safety_margin,
+                0,
+            )
+            still_over_hard_ceiling = (
+                _approx_tokens(summary) + self._turns_tokens(tail) > hard_ceiling
+            )
+            return MemoryResult(summary, tail, 0, summary_was_over_cap, still_over_hard_ceiling)
 
         new_summary = self._safe_summarise(summary, older)
         new_summary_over_cap = self._over_cap(new_summary)


### PR DESCRIPTION
- aura_chat_graph.py / aura_chat.py: profile fast-path no longer hardcodes student-only phrasing ("Roll Number", "enrolled in Semester X", default name "Student") for faculty/dean/registrar queries. Faculty now get Employee ID / department phrasing instead.

- conversation_memory.py: fixed a loophole where the "nothing left to fold"  branch force-forked a new thread whenever the *soft* internal history budget was exceeded, rather than the model's actual context window. A single verbose answer could trip this on every subsequent message,  spawning a new thread each turn. Now only forks against a real hard ceiling derived from model_context_tokens. Verified against the existing test suite (9/9 pass, including the two "fork once, self-heal" tests that an earlier draft of this fix incorrectly broke).

- use-aura-chat.ts / MessageList.tsx: a reply with no sources was stored as `citations: undefined` instead of `[]`, which could fall back to the previous message's `activeCitations` and show a stale source card. Now always persists the resolved (possibly empty) array, and the streaming fallback in MessageList only applies to the message that is actively streaming, not "whichever assistant message happens to be last."

- ChatShell.tsx: Composer was rendered in two different tree positions depending on whether the chat was empty (nested inside EmptyState) or not (bare sibling). React unmounted/remounted the <textarea> the instant the first message was sent, causing the mobile keyboard to flicker and the caret to jump/vanish mid-type. Composer now renders once, in a single stable tree position, regardless of hasMessages.

- EmptyState.tsx: dropped the now-unused `children` prop (previously used to nest Composer inside it) and added faculty-specific starter prompts (Consultancy policy / Seed grant / Course file template / class schedule) instead of showing the generic student/admissions prompts.

- FacultyDashboard.tsx: updated quick-action prompts to match the same faculty-relevant sample questions.

Not addressed in this commit: chat thread not persisting across a page refresh for signed-in users (couldn't reproduce a failure in the persistence/hydration/server-merge path via static review or existing tests — needs a live repro to pin down).