### PR TITLE
feat(identity): add 2026 branch codes for CSAI, ECE-AI, BSMS-DS, BSMS-IT

### DIFF
--- a/server/api/academic_scope_persist.py
+++ b/server/api/academic_scope_persist.py
@@ -35,10 +35,14 @@ _DEPT_TO_PROGRAMME: dict[str, tuple[str, str]] = {
     "ICTCS": ("btech-ict", "undergraduate"),  # prefer btech-ict until CS corpus exists
     "MnC": ("btech-mnc", "undergraduate"),
     "EVD": ("btech-evd", "undergraduate"),
+    "CSAI": ("btech-csai", "undergraduate"),
+    "ECEAI": ("btech-ece-ai", "undergraduate"),
     "MTech": ("mtech-ict", "postgraduate"),
     "MScIT": ("msc-it", "postgraduate"),
     "MScDS": ("msc-ds", "postgraduate"),
     "PhD": ("phd", "doctoral"),
+    "BSMSDS": ("bs-ms-dsai", "undergraduate"),
+    "BSMSIT": ("bs-ms-it", "undergraduate"),
 }
 
 _DEGREE_DURATION_YEARS = {

--- a/server/api/routes/identity_routes.py
+++ b/server/api/routes/identity_routes.py
@@ -135,7 +135,16 @@ def _validate_email_domain(email: str) -> None:
 
 
 def _infer_role_and_cohort(email: str) -> dict:
-    """Infer student/faculty/guest role, branch (dept), and default cohort from email."""
+    """Infer student/faculty/guest role, branch (dept), and default cohort from email.
+
+    Branch is read off digits 5-6 (0-indexed [4:6]) of the 9-digit student id,
+    e.g. 202601010 -> "01". Current (2026 batch) mapping:
+        01 ICT/CS   03 MnC   04 EVD   05 CS-AI   06 ECE-AI
+        31 BS-MS DS 32 BS-MS IT
+    (11/12/18/21 are existing PG/PhD codes, unrelated to this table.)
+    Digits 5-7 == "014" is the pre-existing ICT-CS specialization override
+    within the 01 (ICT) branch and takes precedence over the 2-digit table.
+    """
     prefix = email.split("@")[0].lower().strip()
     role = "guest"
     erp_id = f"GUEST_{prefix.upper()}"
@@ -165,6 +174,10 @@ def _infer_role_and_cohort(email: str) -> dict:
             dept = "MnC"
         elif prog2 == "04":
             dept = "EVD"
+        elif prog2 == "05":
+            dept = "CSAI"
+        elif prog2 == "06":
+            dept = "ECEAI"
         elif prog2 == "11":
             dept = "MTech"
         elif prog2 == "12":
@@ -173,6 +186,10 @@ def _infer_role_and_cohort(email: str) -> dict:
             dept = "MScDS"
         elif prog2 == "21":
             dept = "PhD"
+        elif prog2 == "31":
+            dept = "BSMSDS"
+        elif prog2 == "32":
+            dept = "BSMSIT"
         else:
             dept = "ICT"
 
@@ -272,4 +289,3 @@ def resolve_identity(
         "current_sem": current_sem,
         "current_sec": current_sec,
     }
-

--- a/server/rag/pipeline/tests/test_identity_routes.py
+++ b/server/rag/pipeline/tests/test_identity_routes.py
@@ -109,6 +109,26 @@ def test_branch_code_evd():
     assert _student_dept("202404001") == "EVD"
 
 
+def test_branch_code_csai():
+    # prog code "05" (e.g. 202605001) → CSAI
+    assert _student_dept("202605001") == "CSAI"
+
+
+def test_branch_code_eceai():
+    # prog code "06" (e.g. 202606001) → ECEAI
+    assert _student_dept("202606001") == "ECEAI"
+
+
+def test_branch_code_bsms_ds():
+    # prog code "31" (e.g. 202631001) → BSMSDS
+    assert _student_dept("202631001") == "BSMSDS"
+
+
+def test_branch_code_bsms_it():
+    # prog code "32" (e.g. 202632001) → BSMSIT
+    assert _student_dept("202632001") == "BSMSIT"
+
+
 def test_branch_code_mtech():
     # prog code "11" (e.g. 202411001) → MTech
     assert _student_dept("202411001") == "MTech"


### PR DESCRIPTION

Add the four branch codes introduced for the 2026 admission batch to the student-ID → department inference table, so students in these branches get their correct department on login instead of silently falling back to the "unknown code" ICT default.

- identity_routes.py: map digits 5-6 of the 9-digit student ID (05=CSAI, 06=ECEAI, 31=BSMSDS, 32=BSMSIT) alongside the existing 01/03/04/11/12/18/21 codes. No change to the existing 014 ICT-CS sub-code override.

- academic_scope_persist.py: map the four new dept codes to their corpus programme_ids (btech-csai, btech-ece-ai, bs-ms-dsai,
  bs-ms-it) so RAG document scoping resolves for these students too,  not just login/profile.

- test_identity_routes.py: add branch-code tests for all four new codes, following the existing per-code test pattern.

Department resolved here already flows through unchanged into the timetable dept-narrowing in pipeline/timetable/service.py (falls back to unfiltered rows on no match, so this is safe even where branch-tagged timetable data isn't imported yet).