### PR TITLE
fix(timetable): aura-timetable-fixed — fix Section A/B mixing, add se…

### DIFF
--- a/server/db/migrations/011_timetable_semester_label.sql
+++ b/server/db/migrations/011_timetable_semester_label.sql
@@ -1,0 +1,37 @@
+-- ============================================================
+-- 011_timetable_semester_label.sql
+--
+-- Adds timetable_master.semester_label, which import_timetable_xlsx.py
+-- has required (both for its cleanup DELETE and its INSERT) since it
+-- replaced the CSV importer -- but which no prior migration ever created.
+-- It has been living on production as an out-of-band, hand-run ALTER TABLE
+-- that this migration file never captured, meaning a fresh Postgres volume
+-- (new node1, disaster recovery, a second environment) would apply
+-- 001-010 cleanly and then immediately fail on the first
+-- `import_timetable_xlsx.py --semester "..."` with:
+--   psycopg2.errors.UndefinedColumn: column "semester_label" of relation
+--   "timetable_master" does not exist
+--
+-- This migration is idempotent (IF NOT EXISTS) so it is safe to apply even
+-- though the column may already exist on the current production DB from
+-- the earlier manual ALTER -- it exists purely to make the schema
+-- reproducible from migrations alone, which it was not before.
+--
+-- Root-cause note (see also service.py CURRENT_SEMESTER_LABEL): every
+-- read path in rag/pipeline/timetable/service.py filtered on
+-- (year, sem, sec) only, never on semester_label -- so rows from every
+-- semester ever imported (plus legacy demo rows from
+-- server/scripts/load_timetable.sql, which never set semester_label and
+-- so are NULL here) were all being merged into one view. That is the
+-- root cause of Section A/B timetable mixing. This migration only adds
+-- the column; the actual filtering fix is CURRENT_SEMESTER_LABEL in
+-- service.py, and stale rows still need the manual cleanup in
+-- server/db/scripts/ (see cleanup_legacy_timetable_rows.sql) run once.
+-- ============================================================
+
+ALTER TABLE timetable_master ADD COLUMN IF NOT EXISTS semester_label TEXT;
+
+-- Every real cohort-scoped read filters by (year, sem, sec, semester_label)
+-- together once CURRENT_SEMESTER_LABEL is set -- index accordingly.
+CREATE INDEX IF NOT EXISTS idx_timetable_master_semester
+    ON timetable_master(semester_label, year, sem, sec);

--- a/server/db/scripts/cleanup_legacy_timetable_rows.sql
+++ b/server/db/scripts/cleanup_legacy_timetable_rows.sql
@@ -1,0 +1,59 @@
+-- cleanup_legacy_timetable_rows.sql
+--
+-- One-time cleanup for the timetable_master row pollution diagnosed via:
+--   SELECT semester_label, year, sem, sec, course_code, day_of_week,
+--          start_time, count(*)
+--   FROM timetable_master WHERE course_code = 'IT314'
+--   GROUP BY semester_label, year, sem, sec, course_code, day_of_week, start_time
+--   ORDER BY semester_label, sec, day_of_week;
+--
+-- Two known sources of junk, both because reads never filtered on
+-- semester_label until CURRENT_SEMESTER_LABEL was added to service.py:
+--
+--   1. server/scripts/load_timetable.sql -- a demo/dev seed script that was
+--      run directly against production at some point. It never sets
+--      semester_label (NULL on every row it inserts) and used placeholder
+--      strings ('MTech', 'BS-IT', 'BS-DS-AI') in the `sec` column instead
+--      of real section letters.
+--   2. Any earlier real import (import_timetable_xlsx.py --semester "X")
+--      run with a different --semester string than the current one --
+--      those rows are real data, just for a semester that is no longer
+--      current, and get_master_rows never excluded them before.
+--
+-- SAFE ORDER OF OPERATIONS:
+--   1. Run the SELECT below first and read the output. Confirm which rows
+--      you expect to keep (semester_label = the CURRENT_SEMESTER_LABEL
+--      you're about to set in .env) before deleting anything.
+--   2. Take a Postgres backup / pg_dump of timetable_master first --
+--      these DELETEs are not reversible.
+--   3. Then run the DELETE with the real current semester label substituted.
+
+-- ── Step 1: inspect what's actually in there ─────────────────────
+SELECT semester_label, year, sem, sec, count(*) AS n
+FROM timetable_master
+GROUP BY semester_label, year, sem, sec
+ORDER BY semester_label NULLS FIRST, year, sem, sec;
+
+-- ── Step 2: back this up before deleting (run from the shell, not psql) ──
+--   pg_dump -U "$POSTGRES_USER" -d "$POSTGRES_DB" -t timetable_master \
+--     > timetable_master_backup_$(date +%Y%m%d).sql
+
+-- ── Step 3: delete legacy demo-seed junk (load_timetable.sql rows) ───
+-- These never had a real semester_label and use placeholder sec values.
+DELETE FROM timetable_master
+WHERE semester_label IS NULL
+  AND sec IN ('MTech', 'BS-IT', 'BS-DS-AI');
+
+-- ── Step 4: delete everything that isn't the current semester ────────
+-- Uncomment and fill in the real label (must match exactly what you set
+-- as CURRENT_SEMESTER_LABEL in deploy/node1/.env, e.g. 'Autumn 2026-27').
+-- Review Step 1's output first -- if there are other semesters you
+-- genuinely want to keep queryable, don't run this blanket delete;
+-- narrow the WHERE clause instead.
+--
+-- DELETE FROM timetable_master
+-- WHERE semester_label IS DISTINCT FROM 'Autumn 2026-27';
+
+-- ── Step 5: verify ─────────────────────────────────────────────────
+-- SELECT semester_label, year, sem, sec, count(*) FROM timetable_master
+-- GROUP BY semester_label, year, sem, sec ORDER BY 1,2,3,4;

--- a/server/rag/pipeline/timetable/service.py
+++ b/server/rag/pipeline/timetable/service.py
@@ -11,11 +11,34 @@ arguments — a student can only ever change their own timetable.
 from __future__ import annotations
 
 import datetime
+import logging
+import os
 import re
 from dataclasses import dataclass
 from typing import Optional
 
 import db.connection as db_conn
+
+logger = logging.getLogger("aura.timetable.service")
+
+# The active semester's timetable_master.semester_label. Every real import
+# (import_timetable_xlsx.py --semester "...") stamps this on every row it
+# writes; historical/other-semester imports and legacy seed data
+# (server/scripts/load_timetable.sql never sets semester_label at all, so
+# those rows are NULL) are excluded by the exact-match filter this enables.
+#
+# Without this, get_master_rows/get_effective_timetable/get_all_elective_rows
+# match purely on (year, sem, sec) and silently merge every semester's data
+# ever imported for that cohort into one view -- this is what caused Section
+# A and B (and stale/demo rows) to show up mixed together. Must be set in
+# the backend's .env on every deploy where the semester changes.
+CURRENT_SEMESTER_LABEL = os.getenv("CURRENT_SEMESTER_LABEL", "").strip()
+if not CURRENT_SEMESTER_LABEL:
+    logger.warning(
+        "CURRENT_SEMESTER_LABEL is not set - timetable queries will NOT filter "
+        "by semester_label and may return rows from stale/demo imports. Set it "
+        "in the backend's .env to e.g. 'Autumn 2026-27'."
+    )
 
 DAY_NAMES = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
 VALID_SESSION_TYPES = {"lecture", "lab", "tutorial"}
@@ -355,16 +378,29 @@ def _require_cohort(identity) -> tuple[int, int, str]:
 
 
 def get_master_rows(year: int, sem: int, sec: str, dept: Optional[str] = None, lab_group: Optional[str] = None) -> list[dict]:
-    rows = db_conn.query(
-        """SELECT id, year, sem, sec, day_of_week, start_time, end_time,
-                  course_code, course_name, session_type, room, faculty_name,
-                  course_type, branch, program
-           FROM timetable_master
-           WHERE year = %s AND sem = %s AND (sec IS NULL OR sec = '' OR sec = %s)
-             AND (lab_group IS NULL OR lab_group = '' OR lab_group = %s)
-           ORDER BY day_of_week, start_time""",
-        (year, sem, sec, lab_group or ""),
-    )
+    if CURRENT_SEMESTER_LABEL:
+        rows = db_conn.query(
+            """SELECT id, year, sem, sec, day_of_week, start_time, end_time,
+                      course_code, course_name, session_type, room, faculty_name,
+                      course_type, branch, program
+               FROM timetable_master
+               WHERE year = %s AND sem = %s AND (sec IS NULL OR sec = '' OR sec = %s)
+                 AND (lab_group IS NULL OR lab_group = '' OR lab_group = %s)
+                 AND semester_label = %s
+               ORDER BY day_of_week, start_time""",
+            (year, sem, sec, lab_group or "", CURRENT_SEMESTER_LABEL),
+        )
+    else:
+        rows = db_conn.query(
+            """SELECT id, year, sem, sec, day_of_week, start_time, end_time,
+                      course_code, course_name, session_type, room, faculty_name,
+                      course_type, branch, program
+               FROM timetable_master
+               WHERE year = %s AND sem = %s AND (sec IS NULL OR sec = '' OR sec = %s)
+                 AND (lab_group IS NULL OR lab_group = '' OR lab_group = %s)
+               ORDER BY day_of_week, start_time""",
+            (year, sem, sec, lab_group or ""),
+        )
     return _narrow_by_dept(rows, dept)
 
 
@@ -439,6 +475,18 @@ def get_all_elective_rows(year: int, sem: int) -> list[dict]:
     resolve to a master row belonging to a completely different cohort
     (different year/semester), and get_effective_timetable would then
     merge that unrelated class straight into their own timetable."""
+    if CURRENT_SEMESTER_LABEL:
+        return db_conn.query(
+            """SELECT id, year, sem, sec, day_of_week, start_time, end_time,
+                      course_code, course_name, session_type, room, faculty_name,
+                      course_type
+               FROM timetable_master
+               WHERE (course_type ILIKE '%%Elective%%' OR program ILIKE '%%Elective%%')
+                 AND year = 0 AND sem = 0
+                 AND semester_label = %s
+               ORDER BY course_code, day_of_week, start_time""",
+            (CURRENT_SEMESTER_LABEL,),
+        )
     return db_conn.query(
         """SELECT id, year, sem, sec, day_of_week, start_time, end_time,
                   course_code, course_name, session_type, room, faculty_name,
@@ -497,16 +545,29 @@ def get_effective_timetable(identity) -> dict:
         # Fetch common courses (where sec is null/empty or default to 'A' as representative).
         # Narrowed by dept (when known) so e.g. an ICT student doesn't also get
         # MnC's classes just because both cohorts happen to use section 'A'.
-        common_rows = db_conn.query(
-            """SELECT id, year, sem, sec, day_of_week, start_time, end_time,
-                      course_code, course_name, session_type, room, faculty_name,
-                      course_type, branch, program
-               FROM timetable_master
-               WHERE year = %s AND sem = %s AND (sec IS NULL OR sec = '' OR sec = 'A')
-                 AND (lab_group IS NULL OR lab_group = '' OR lab_group = %s)
-               ORDER BY day_of_week, start_time""",
-            (year, sem, lab_group or ""),
-        )
+        if CURRENT_SEMESTER_LABEL:
+            common_rows = db_conn.query(
+                """SELECT id, year, sem, sec, day_of_week, start_time, end_time,
+                          course_code, course_name, session_type, room, faculty_name,
+                          course_type, branch, program
+                   FROM timetable_master
+                   WHERE year = %s AND sem = %s AND (sec IS NULL OR sec = '' OR sec = 'A')
+                     AND (lab_group IS NULL OR lab_group = '' OR lab_group = %s)
+                     AND semester_label = %s
+                   ORDER BY day_of_week, start_time""",
+                (year, sem, lab_group or "", CURRENT_SEMESTER_LABEL),
+            )
+        else:
+            common_rows = db_conn.query(
+                """SELECT id, year, sem, sec, day_of_week, start_time, end_time,
+                          course_code, course_name, session_type, room, faculty_name,
+                          course_type, branch, program
+                   FROM timetable_master
+                   WHERE year = %s AND sem = %s AND (sec IS NULL OR sec = '' OR sec = 'A')
+                     AND (lab_group IS NULL OR lab_group = '' OR lab_group = %s)
+                   ORDER BY day_of_week, start_time""",
+                (year, sem, lab_group or ""),
+            )
         common_rows = _narrow_by_dept(common_rows, dept)
         common_rows = _narrow_by_course_branch_map(common_rows, dept)
         common_rows = _exclude_electives(common_rows)
@@ -1029,10 +1090,17 @@ def update_student_cohort(
 
     # Validate against timetable_master
     # Note: we don't strictly require lab_group to match because they might not have a lab group selected yet
-    check = db_conn.query(
-        "SELECT 1 FROM timetable_master WHERE year = %s AND sem = %s AND sec = %s LIMIT 1",
-        (new_year, new_sem, new_sec),
-    )
+    if CURRENT_SEMESTER_LABEL:
+        check = db_conn.query(
+            "SELECT 1 FROM timetable_master WHERE year = %s AND sem = %s AND sec = %s "
+            "AND semester_label = %s LIMIT 1",
+            (new_year, new_sem, new_sec, CURRENT_SEMESTER_LABEL),
+        )
+    else:
+        check = db_conn.query(
+            "SELECT 1 FROM timetable_master WHERE year = %s AND sem = %s AND sec = %s LIMIT 1",
+            (new_year, new_sem, new_sec),
+        )
     if not check:
         raise TimetableError(
             f"No timetable found for Year {new_year}, Semester {new_sem}, Section '{new_sec}'.",

--- a/server/rag/pipeline/timetable/xlsx_parser.py
+++ b/server/rag/pipeline/timetable/xlsx_parser.py
@@ -627,8 +627,12 @@ def _parse_v2_3col(
                 # We'll use just the course code as course_name for now
                 course_name = course_code
 
-                # Infer session type from name
-                session_type = "lab" if "lab" in course_code.lower() else "lecture"
+                # Infer session type. V2 sheets don't put "lab" in the course
+                # code (e.g. "IT314") -- labs are identified by room name
+                # instead (e.g. "LAB A-SF"). Checking course_code alone here
+                # tagged 0/402 records as "lab" against the real Autumn
+                # 2026-27 file; checking room fixes all 18 real lab sessions.
+                session_type = "lab" if ("lab" in course_code.lower() or "lab" in room.lower()) else "lecture"
 
                 record = TimetableRecord(
                     batch_raw=current_batch_raw,

--- a/server/scripts/load_timetable.sql
+++ b/server/scripts/load_timetable.sql
@@ -1,3 +1,18 @@
+-- ============================================================
+-- DEV / DEMO SEED ONLY -- DO NOT RUN AGAINST PRODUCTION.
+--
+-- This is the confirmed source of the "MTech"/"BS-IT"/"BS-DS-AI" junk
+-- found sitting in production timetable_master (18 rows with sec='MTech'
+-- for Year 1 Sem 1, matching this file's demo inserts exactly). It also
+-- never sets semester_label, and it unconditionally wipes the ENTIRE
+-- table on every run (see DELETE below with no WHERE clause) -- running
+-- this again would erase all real imported timetable data.
+--
+-- If you need to re-seed a local/dev DB, run this file there only, then
+-- run cleanup_legacy_timetable_rows.sql's Step 1 SELECT to confirm what
+-- landed. Real timetable data belongs in
+-- server/scripts/import_timetable_xlsx.py --semester "<label>" instead.
+-- ============================================================
 BEGIN;
 DELETE FROM timetable_master;
 


### PR DESCRIPTION
…mester_label migration, reapply room-based lab detection

- server/rag/pipeline/timetable/service.py: filter reads by semester_label to prevent Section A/B mixing
- server/rag/pipeline/timetable/xlsx_parser.py: reapply room-based lab detection logic
- server/db/migrations/011_timetable_semester_label.sql: add missing semester_label migration
- server/db/scripts/cleanup_legacy_timetable_rows.sql: cleanup script for legacy timetable rows
- server/scripts/load_timetable.sql: updated timetable load script