### PR TITLE
fix(rag): restore structured dictionary return contract for _resolve_person_name

### DIFF
--- a/server/rag/pipeline/retrieval/retrieval_pipeline.py
+++ b/server/rag/pipeline/retrieval/retrieval_pipeline.py
@@ -781,18 +781,32 @@ class RetrievalPipeline:
                     "(Score: %.2f): first name does not match closely enough",
                     name, cleaned, self.faculty_names_map[best_match[0]], s1,
                 )
-                return name
-            if len(matches) == 1:
-                corrected = self.faculty_names_map[best_match[0]]
-                logger.info("Fuzzy matched faculty name '%s' (cleaned: '%s') to '%s' (Score: %.2f)", name, cleaned, corrected, s1)
-                return corrected
-            s2 = matches[1][1]
-            if s1 == 100.0 or (s1 - s2) >= 8.0:
-                corrected = self.faculty_names_map[best_match[0]]
-                logger.info("Fuzzy matched faculty name '%s' (cleaned: '%s') to '%s' (Score: %.2f)", name, cleaned, corrected, s1)
-                return corrected
-                
-        return name
+                return result
+
+        scored_candidates = []
+        for m in matches:
+            m_name = m[0]
+            corrected = self.faculty_names_map[m_name]
+            score = self._smart_score(cleaned, m_name)
+            scored_candidates.append({"name": corrected, "score": score})
+
+        # Sort by smart score descending
+        scored_candidates.sort(key=lambda x: x["score"], reverse=True)
+
+        highest_score = scored_candidates[0]["score"]
+
+        if highest_score >= 90.0:
+            result["matches"] = scored_candidates[:1]
+            corrected = scored_candidates[0]["name"]
+            logger.info("Fuzzy matched faculty name '%s' (cleaned: '%s') to '%s' (Score: %.2f)", name, cleaned, corrected, highest_score)
+        elif highest_score >= 60.0:
+            result["matches"] = scored_candidates[:3]
+        else:
+            result["matches"] = scored_candidates[:5]
+
+        result["confidence"] = highest_score
+
+        return result
 
     @staticmethod
     def _first_name_agrees(query_lower: str, candidate_lower: str, threshold: float = 60.0) -> bool:


### PR DESCRIPTION
## Summary
Fixes a critical contract mismatch and `AttributeError: 'str' object has no attribute 'get'` regression in `_resolve_person_name` within `server/rag/pipeline/retrieval/retrieval_pipeline.py`.

## Problem & Root Cause
- In `_resolve_person_name`, early returns yielded a structured dictionary (`{"original": name, "matches": [], "confidence": 0.0}`), but matched branches returned a raw `str` (`name` or `corrected`).
- The caller in `get_context()` (line 1116) strictly expects a dictionary and calls `resolution.get("confidence", 0.0)` and `resolution.get("matches", [])`.
- Whenever a name was matched, invoking `resolution.get(...)` triggered `AttributeError: 'str' object has no attribute 'get'`.

## Changes Made
1. **Restored Structured Return**: `_resolve_person_name` now always returns `{"original": name, "matches": [...], "confidence": ...}`.
2. **Preserved Smart Scoring**: Candidate matches are scored with `_smart_score()` and sorted in descending order, populating `result["matches"]`, candidate names, and `result["confidence"]`.
3. **Preserved Safety Guards & Logging**:
   - Retained the `_first_name_agrees` check for candidates with WRatio >= 80.0 to prevent incorrect surname-only swaps.
   - Retained rejection logging and successful match logging (`logger.info`).

## Test Plan
- [x] Syntax & Bytecode Compilation: `python3 -m compileall server/rag/pipeline/retrieval/retrieval_pipeline.py` passes cleanly.
- [x] Unit Tests: `test_faculty_timetable.py` passes 5/5.
- [x] Direct Contract & Edge Case Verification: Verified exact matches, title stripping (`Prof. Abhishek Gupta`), first-name disagreement rejections (`Hari Sharma` vs `Madhu Kant Sharma`), and short/empty inputs.
